### PR TITLE
fix: add offline scope for refresh token support

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -18,7 +18,7 @@ export const WHOOP_TOKEN_URL =
 
 /** All OAuth scopes required by the 6 MCP tools */
 export const WHOOP_REQUIRED_SCOPES =
-  "read:recovery read:cycles read:workout read:sleep read:profile read:body_measurement";
+  "offline read:recovery read:cycles read:workout read:sleep read:profile read:body_measurement";
 
 /** Default OAuth redirect URI for the local callback server */
 export const WHOOP_REDIRECT_URI = "http://localhost:3000/callback";


### PR DESCRIPTION
## Problem

Without the `offline` scope in the OAuth request, WHOOP does not return a refresh token. This means users are forced to re-authenticate every time their access token expires (~1 hour).

## Fix

Add `offline` to `WHOOP_REQUIRED_SCOPES` in `src/api/endpoints.ts`:

```diff
- "read:recovery read:cycles read:workout read:sleep read:profile read:body_measurement"
+ "offline read:recovery read:cycles read:workout read:sleep read:profile read:body_measurement"
```

## Testing

After this change, `~/.whoop-mcp/tokens.json` will contain a `refresh_token` field, and the existing token refresh logic in `src/auth/oauth.ts` will handle silent re-authentication automatically.