### PR TITLE
fix: read error response body once to avoid "Body is unusable" crash on 401

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -143,10 +143,19 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
   }
 
   async function parseErrorBody(response: Response): Promise<unknown> {
+    // Read the body stream exactly once. response.json() consumes the body even
+    // when JSON parsing fails, so falling back to response.text() in the catch
+    // throws "Body is unusable: Body has already been read". WHOOP returns some
+    // error responses (e.g. 401 with the plain-text body "Authorization was not
+    // valid") under a Content-Type: application/json header, which makes
+    // response.json() throw a SyntaxError and triggers exactly that double-read.
+    // Because the error escapes here, it short-circuits the status === 401
+    // refresh branch below, so automatic token refresh never runs.
+    const text = await response.text();
     try {
-      return await response.json();
+      return JSON.parse(text);
     } catch {
-      return await response.text();
+      return text;
     }
   }
 

--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -188,7 +188,9 @@ describe("createWhoopClient", () => {
         statusText: "Too Many Requests",
         headers: { get: () => null },
         json: () => Promise.resolve({ retry_after: 30 }),
-        text: () => Promise.resolve("rate limited"),
+        // text() and json() must reflect the same bytes — a real Response body
+        // is a single stream, and parseErrorBody now reads it once via text().
+        text: () => Promise.resolve(JSON.stringify({ retry_after: 30 })),
       } as unknown as Response;
       mockFetch
         .mockResolvedValueOnce(response429)
@@ -547,6 +549,58 @@ describe("createWhoopClient", () => {
       );
     });
 
+    // Regression: WHOOP returns 401 with the plain-text body "Authorization was
+    // not valid" under a Content-Type: application/json header. A real Response
+    // body can only be consumed once, so reading json() (which throws on the
+    // non-JSON text) and then text() throws "Body is unusable: Body has already
+    // been read". That TypeError escaped parseErrorBody and short-circuited this
+    // refresh path, leaving the client permanently broken once the access token
+    // expired. The mock below faithfully models single-read body semantics —
+    // unlike the independent json()/text() resolvers used elsewhere in this file
+    // — so it fails against the old double-read implementation.
+    it("refreshes token on 401 when the error body is non-JSON (regression: 'Body is unusable')", async () => {
+      const NEW_TOKEN = "refreshed_token_xyz";
+      function mock401NonJsonResponse(): Response {
+        let bodyUsed = false;
+        const consume = (): void => {
+          if (bodyUsed) {
+            throw new TypeError("Body is unusable: Body has already been read");
+          }
+          bodyUsed = true;
+        };
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { get: () => "application/json" },
+          json: () => {
+            consume();
+            return Promise.reject(new SyntaxError("Unexpected token 'A', \"Authorizat\"... is not valid JSON"));
+          },
+          text: () => {
+            consume();
+            return Promise.resolve("Authorization was not valid");
+          },
+        } as unknown as Response;
+      }
+
+      mockFetch
+        .mockResolvedValueOnce(mock401NonJsonResponse())
+        .mockResolvedValueOnce(mockJsonResponse({ user_id: 42 }));
+      const onTokenRefresh = vi.fn().mockResolvedValue(NEW_TOKEN);
+      const client = createWhoopClient({
+        accessToken: TEST_TOKEN,
+        baseUrl: TEST_BASE_URL,
+        onTokenRefresh,
+      });
+
+      const result = await client.get<{ user_id: number }>("/v2/user/profile/basic");
+
+      expect(result.user_id).toBe(42);
+      expect(onTokenRefresh).toHaveBeenCalledOnce();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it("throws WhoopApiError if retry after refresh also returns 401", async () => {
       mockFetch.mockResolvedValueOnce(mock401Response()).mockResolvedValueOnce(mock401Response());
       const onTokenRefresh = vi.fn().mockResolvedValue("new_token");
@@ -678,6 +732,7 @@ describe("createWhoopClient", () => {
           statusText: "Too Many Requests",
           headers: headers429,
           json: () => Promise.resolve({ message: "rate limited" }),
+          text: () => Promise.resolve(JSON.stringify({ message: "rate limited" })),
         } as unknown as Response)
         .mockResolvedValueOnce({
           ok: true,
@@ -706,6 +761,7 @@ describe("createWhoopClient", () => {
           statusText: "Too Many Requests",
           headers: headers429,
           json: () => Promise.resolve({ message: "rate limited" }),
+          text: () => Promise.resolve(JSON.stringify({ message: "rate limited" })),
         } as unknown as Response)
         .mockResolvedValueOnce({
           ok: true,


### PR DESCRIPTION
## Bug

Once the WHOOP access token expires (~1h), every API call fails with
`TypeError: Body is unusable: Body has already been read` instead of refreshing
the token. The client stays broken until the process restarts.

## Root cause

`parseErrorBody` (`src/api/client.ts`) reads the response body twice:

```ts
async function parseErrorBody(response: Response): Promise<unknown> {
  try {
    return await response.json();
  } catch {
    return await response.text();   // body already consumed by json()
  }
}
```

A `Response` body is a single-use stream. When `response.json()` fails to parse,
it has **already consumed** the body, so the `response.text()` fallback throws
`Body is unusable: Body has already been read`.

WHOOP triggers exactly this: a 401 returns the **plain-text** body
`Authorization was not valid` under a `Content-Type: application/json` header, so
`response.json()` throws a `SyntaxError`. Verified against the live API:

```
status: 401
content-type: "application/json"
body: "Authorization was not valid"   // not JSON
```

Critically, the `TypeError` escapes `parseErrorBody` at the first 401 (the
`const body = await parseErrorBody(response)` line) — **before** the
`status === 401` refresh branch a few lines below. So `onTokenRefresh` never
runs and the client cannot recover after the token expires.

## Fix

Read the body once via `text()`, then `JSON.parse` with a text fallback:

```ts
const text = await response.text();
try {
  return JSON.parse(text);
} catch {
  return text;
}
```

For real responses `text()` and `json()` are the same bytes, so behavior is
unchanged for JSON error bodies; non-JSON bodies now fall back cleanly without a
double-read.

## Tests

Following the Prove-It pattern in `CONTRIBUTING.md`, this adds a regression test
whose `Response` mock enforces **single-read** body semantics (a second body read
throws the real `Body is unusable` error). It fails against the old
implementation and passes with the fix.

Note: the existing error-body mocks defined `json()` and `text()` as independent
resolvers (and some returned *different* values from each), which is why the bug
shipped green — no test modeled that a real body can only be read once. Three 429
mocks are updated so `json()` and `text()` reflect the same bytes.

`npm test` (220), `npm run typecheck`, `npm run build`, `npm run lint` all pass.
