### PR TITLE
fix: date-only params cause 404, parseErrorBody double-reads response body

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -214,9 +214,14 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
 
   async function parseErrorBody(response: Response): Promise<unknown> {
     try {
-      return await response.json();
+      const text = await response.text();
+      try {
+        return JSON.parse(text);
+      } catch {
+        return text;
+      }
     } catch {
-      return await response.text();
+      return "unable to read response body";
     }
   }
 

--- a/src/tools/collection-utils.ts
+++ b/src/tools/collection-utils.ts
@@ -23,16 +23,30 @@ export interface CollectionParams {
  * If already ISO 8601, passes through unchanged.
  * Returns undefined if input is undefined.
  */
+const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Normalize a date-only string (YYYY-MM-DD) to a full ISO 8601 datetime.
+ * The WHOOP API requires a full datetime for start/end query parameters;
+ * date-only strings return HTTP 404.
+ */
+function normalizeToISO8601(value: string): string {
+  if (DATE_ONLY_REGEX.test(value)) {
+    return value + "T00:00:00.000Z";
+  }
+  return value;
+}
+
 function resolveStart(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
   try {
     const resolved = resolveDateExpression(value);
-    return resolved.start;
+    return normalizeToISO8601(resolved.start);
   } catch (e) {
     if (e instanceof InvalidDateExpression) {
       throw e;
     }
-    return value;
+    return normalizeToISO8601(value);
   }
 }
 
@@ -45,12 +59,12 @@ function resolveEnd(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
   try {
     const resolved = resolveDateExpression(value);
-    return resolved.end;
+    return normalizeToISO8601(resolved.end);
   } catch (e) {
     if (e instanceof InvalidDateExpression) {
       throw e;
     }
-    return value;
+    return normalizeToISO8601(value);
   }
 }
 


### PR DESCRIPTION
## Summary

Two bugs that prevent collection tools (`get_recovery_collection`, `get_sleep_collection`, `get_workout_collection`, `get_cycle_collection`) from working in headless/server environments.

### Bug 1: `parseErrorBody` double-reads response body (`client.ts`)

When the WHOOP API returns a non-2xx error response, `parseErrorBody()` calls `response.json()` first. If the body isn't valid JSON (e.g. plain text like `"HTTP 404 Not Found"`), the `json()` call **consumes the body stream**. The `catch` block then tries `response.text()` on the same body, which throws:

```
Body is unusable: Body has already been read
```

This error masks the **actual** API error, making debugging impossible. Users see a generic "Body is unusable" error instead of the real HTTP status/message.

**Fix**: Read `text()` first, then `JSON.parse()` on the resulting string.

### Bug 2: Date-only query params return 404 (`collection-utils.ts`)

Collection tools accept date strings like `"2026-07-05"` which match the `ISO_8601_REGEX` in `date-utils.ts` and pass through unchanged via `resolveStart()`/`resolveEnd()`. However, the **WHOOP API requires a full ISO 8601 datetime** for `start`/`end` query parameters:

```
# This returns 404:
GET /v2/recovery?start=2026-07-05

# This returns 200:
GET /v2/recovery?start=2026-07-05T00:00:00.000Z
```

**Fix**: Added `normalizeToISO8601()` helper that appends `T00:00:00.000Z` (for start) to date-only strings before sending to the API. Relative expressions ("last 7 days", "today", etc.) already produce full datetime strings so they're unaffected.

## Testing

Tested against live WHOOP API with valid OAuth tokens:

```bash
# Before fix: "Body is unusable: Body has already been read" (masked 404)
# After fix: returns recovery records correctly
get_recovery_collection({ start: "2026-07-05", end: "2026-07-08" })
```

Environment: Node.js v22.22.3, whoop-ai-mcp v0.6.0, headless Docker container.

## Test Plan

- [ ] `get_recovery_collection` with date-only params returns data
- [ ] `get_sleep_collection` with date-only params returns data
- [ ] API error responses show the real error message (not "Body is unusable")
- [ ] Existing relative date expressions ("last 7 days", etc.) still work
- [ ] `get_today` still works (unchanged — uses cache + limit param)