### PR TITLE
docs(deploy): add update.sh one-step deploy script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,48 @@
-# WHOOP Developer App credentials
+# ---------------------------------------------------------------------------
+# WHOOP Developer App credentials (always required)
 # Create an app at https://developer.whoop.com
+# ---------------------------------------------------------------------------
 WHOOP_CLIENT_ID=your_client_id_here
 WHOOP_CLIENT_SECRET=your_client_secret_here
 WHOOP_REDIRECT_URI=http://localhost:3000/callback
+
+# ---------------------------------------------------------------------------
+# Transport (default: stdio for local Claude Desktop / Claude Code)
+# Set to "http" (or "both") to expose the server over the network for a
+# hosted deployment reachable by claude.ai web/mobile.
+# ---------------------------------------------------------------------------
+MCP_TRANSPORT=stdio
+
+# ---------------------------------------------------------------------------
+# HTTP transport settings (only used when MCP_TRANSPORT=http or both)
+# ---------------------------------------------------------------------------
+# Admin bearer token for /mcp AND the seed the connector's JWT signing key is
+# derived from. MUST be >= 32 chars. Generate with: openssl rand -hex 32
+MCP_AUTH_TOKEN=
+# Listen interface. Defaults to 127.0.0.1 (loopback, safe). A hosted container
+# behind a TLS proxy must set this to 0.0.0.0 (the Dockerfile already does).
+MCP_HOST=127.0.0.1
+MCP_PORT=3000
+# Comma-separated CORS allowlist (e.g. https://claude.ai)
+MCP_ALLOWED_ORIGINS=
+# Set to 1 only when behind a trusted reverse proxy (Fly.io / Railway / etc.)
+MCP_TRUST_PROXY=0
+LOG_LEVEL=info
+LOG_FORMAT=json
+
+# ---------------------------------------------------------------------------
+# OAuth 2.1 connector for claude.ai web/mobile (only used in HTTP mode).
+# Set all three to enable it; the connector mounts on the same port as /mcp.
+# ---------------------------------------------------------------------------
+# Human-facing password typed into the claude.ai connector dialog (>= 12 chars).
+# Generate with: openssl rand -base64 24
+MCP_CONNECTOR_PASSWORD=
+# Public https:// origin claude.ai reaches (used as the OAuth issuer).
+PUBLIC_URL=
+# Comma-separated exact-match redirect URI allowlist.
+# For claude.ai use: https://claude.ai/api/mcp/auth_callback
+ALLOWED_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback
+# Optional: override the HKDF-derived JWT signing key with an explicit secret.
+# MCP_JWT_SECRET=
+# Optional: override the advertised OAuth client id (default whoop-mcp-connector).
+# MCP_OAUTH_CLIENT_ID=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-25
+
+Hardening pass for **hosted deployments** (fork maintained at
+`github.com/codeOfJannik/whoop-mcp`).
+
+### Fixed
+- **OAuth connector was non-functional over HTTP** — the connector issued JWT
+  access tokens to claude.ai web/mobile clients, but the `/mcp` route only
+  accepted the static `MCP_AUTH_TOKEN`, so every authenticated request from a
+  connector client returned `401`. `/mcp` now accepts **either** the static
+  admin bearer **or** a valid connector-issued JWT (verified via
+  `provider.verifyAccessToken`). The SSE re-auth sweep uses the same verifier.
+- **Missing runtime dependencies** — `express`, `express-rate-limit`, and
+  `jose` are used by the OAuth connector but were absent from `dependencies`,
+  so a clean `npm install` produced a runtime `MODULE_NOT_FOUND` crash the
+  moment the connector loaded. They are now declared.
+
+### Security
+- **`MCP_AUTH_TOKEN` strength is now enforced** (≥32 chars) in HTTP mode. The
+  connector's JWT signing key is HKDF-derived from this token using public
+  salt/info constants, so a weak value made connector access tokens forgeable.
+  The server fails fast with a clear error and an `openssl rand -hex 32` hint.
+- **Safe-by-default bind address** — `MCP_HOST` now defaults to `127.0.0.1`
+  (loopback) instead of `0.0.0.0`, so a local/dev HTTP run no longer exposes
+  WHOOP data on the LAN by accident. The Dockerfile continues to set
+  `0.0.0.0` for container deployments. A non-loopback bind now logs a warning.
+
+### Added
+- `.env.example` now documents all HTTP-transport and OAuth-connector env vars.
+
 ## [0.6.0] - 2026-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Hardening pass for **hosted deployments** (fork maintained at
 `github.com/codeOfJannik/whoop-mcp`).
 
 ### Fixed
+- **Connector password page blocked the OAuth redirect** — the page's CSP was
+  `form-action 'self'`, which browsers enforce across the post-authorization
+  302 back to the client. The redirect to `https://claude.ai/...` was refused
+  (`Refused to load ... form-action`), so the flow died one step from done. The
+  password page now emits `form-action 'self' <redirect_uri origins>`.
 - **OAuth connector was non-functional over HTTP** — the connector issued JWT
   access tokens to claude.ai web/mobile clients, but the `/mcp` route only
   accepted the static `MCP_AUTH_TOKEN`, so every authenticated request from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Hardening pass for **hosted deployments** (fork maintained at
 `github.com/codeOfJannik/whoop-mcp`).
 
 ### Fixed
+- **HTTP transport dropped every request after the first (stateless clients)** —
+  the server used a single shared *stateful* `StreamableHTTPServerTransport`,
+  which accepts one `initialize` and rejects every later one with `400`. Clients
+  that re-`initialize` on each turn without reusing an `Mcp-Session-Id`
+  (claude.ai web/mobile) worked once, then failed on every subsequent call. The
+  HTTP transport now builds a fresh MCP server + session-less transport **per
+  request** (stateless mode) via a `createMcpServer` factory.
 - **Connector password page blocked the OAuth redirect** — the page's CSP was
   `form-action 'self'`, which browsers enforce across the post-authorization
   302 back to the client. The redirect to `https://claude.ai/...` was refused

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ npm install -g whoop-ai-mcp
 ### From source
 
 ```bash
-git clone https://github.com/shashankswe2020-ux/whoop-mcp.git
+git clone https://github.com/codeOfJannik/whoop-mcp.git
 cd whoop-mcp
 npm install
 npm run build
@@ -632,10 +632,17 @@ to your personal WHOOP data over the network. A production-ready
 [Dockerfile](Dockerfile) is included.
 
 > **Security warning.** When running over HTTP you are exposing your WHOOP data
-> behind a single bearer token. Use a strong random `MCP_AUTH_TOKEN`
-> (`openssl rand -hex 32`), only deploy behind TLS, restrict
-> `MCP_ALLOWED_ORIGINS`, and treat the host as a personal-use deployment — not
-> a multi-tenant service.
+> behind a single bearer token, and this server authenticates with **one**
+> WHOOP account (yours) — anyone who holds the bearer token or connector
+> password can read all of your health data. Use a strong random
+> `MCP_AUTH_TOKEN` (`openssl rand -hex 32`; **≥32 chars is enforced** in HTTP
+> mode), only deploy behind TLS, restrict `MCP_ALLOWED_ORIGINS`, and treat the
+> host as a single-user personal deployment — not a multi-tenant service.
+>
+> `MCP_HOST` defaults to `127.0.0.1` (loopback) so a local HTTP run is not
+> exposed on your network. Container/cloud deployments must bind `0.0.0.0`
+> (the included Dockerfile already does this) and rely on the platform's
+> firewall + TLS-terminating proxy for isolation.
 
 ### Image characteristics
 
@@ -673,11 +680,11 @@ Required env vars (HTTP mode):
 | Variable                | Required | Default      | Notes                                                       |
 | ----------------------- | -------- | ------------ | ----------------------------------------------------------- |
 | `MCP_TRANSPORT`         | no       | `http`       | Image default; override with `stdio` or `both` if needed.   |
-| `MCP_AUTH_TOKEN`        | **yes**  | —            | Bearer token clients must send. Generate ≥32 random bytes.  |
+| `MCP_AUTH_TOKEN`        | **yes**  | —            | Admin bearer token clients must send. **≥32 chars enforced.** Generate with `openssl rand -hex 32`. |
 | `WHOOP_CLIENT_ID`       | **yes**  | —            | From your WHOOP developer app.                              |
 | `WHOOP_CLIENT_SECRET`   | **yes**  | —            | From your WHOOP developer app.                              |
 | `MCP_PORT`              | no       | `3000`       | Listen port.                                                |
-| `MCP_HOST`              | no       | `0.0.0.0`    | Listen interface.                                           |
+| `MCP_HOST`              | no       | `127.0.0.1`  | Listen interface. Loopback by default; set `0.0.0.0` for containers (Dockerfile already does). |
 | `MCP_ALLOWED_ORIGINS`   | no       | (none)       | Comma-separated CORS allowlist.                             |
 | `MCP_TRUST_PROXY`       | no       | `0`          | Set `1` when behind a reverse proxy (Fly/Railway).          |
 | `LOG_LEVEL`             | no       | `info`       | `debug`/`info`/`warn`/`error`.                              |
@@ -760,14 +767,18 @@ fly secrets set \
   advertised client id (default `whoop-mcp-connector`).
 
 In claude.ai → Settings → Connectors → Add custom connector, point it at
-`PUBLIC_URL/mcp` and supply `MCP_CONNECTOR_PASSWORD` when prompted.
+`PUBLIC_URL/mcp` and supply `MCP_CONNECTOR_PASSWORD` when prompted. After the
+OAuth handshake, claude.ai (web and mobile) presents a connector-issued JWT on
+every `/mcp` request; the server verifies it alongside the static admin bearer,
+so both Claude Desktop/Code (static token) and claude.ai (OAuth JWT) work
+against the same endpoint.
 
 ## Development
 
 ### Setup
 
 ```bash
-git clone https://github.com/shashankswe2020-ux/whoop-mcp.git
+git clone https://github.com/codeOfJannik/whoop-mcp.git
 cd whoop-mcp
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -631,6 +631,12 @@ hosting so that web/mobile MCP clients (e.g. claude.ai connectors) can connect
 to your personal WHOOP data over the network. A production-ready
 [Dockerfile](Dockerfile) is included.
 
+> 💸 **Free always-on hosting:** see
+> [docs/deploy/gcp-e2-micro-duckdns.md](docs/deploy/gcp-e2-micro-duckdns.md)
+> for a step-by-step ~$0/month setup on a Google Cloud Always-Free `e2-micro`
+> VM with Caddy (free Let's Encrypt TLS) and a DuckDNS hostname — reachable by
+> claude.ai web and mobile.
+
 > **Security warning.** When running over HTTP you are exposing your WHOOP data
 > behind a single bearer token, and this server authenticates with **one**
 > WHOOP account (yours) — anyone who holds the bearer token or connector

--- a/docs/deploy/Caddyfile.example
+++ b/docs/deploy/Caddyfile.example
@@ -9,6 +9,9 @@
 # /mcp, /authorize, /token, /.well-known/*, /health — to the loopback server.
 
 YOURSUB.duckdns.org {
+	# Access logs to the journal (journalctl -u caddy) — handy for debugging
+	# which requests hit /mcp and what status they got. Authorization is redacted.
+	log
 	encode gzip
 	reverse_proxy 127.0.0.1:3000
 }

--- a/docs/deploy/Caddyfile.example
+++ b/docs/deploy/Caddyfile.example
@@ -1,0 +1,14 @@
+# Caddy reverse proxy for the WHOOP MCP server.
+#
+# Install to: /etc/caddy/Caddyfile   (replace YOURSUB with your DuckDNS name)
+# Then:  sudo systemctl restart caddy
+#
+# Caddy automatically obtains and renews a free Let's Encrypt certificate for
+# this hostname via the HTTP-01 challenge (ports 80 + 443 must be open and
+# YOURSUB.duckdns.org must resolve to this VM). It forwards every path —
+# /mcp, /authorize, /token, /.well-known/*, /health — to the loopback server.
+
+YOURSUB.duckdns.org {
+	encode gzip
+	reverse_proxy 127.0.0.1:3000
+}

--- a/docs/deploy/bootstrap-vm.sh
+++ b/docs/deploy/bootstrap-vm.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# One-time VM bootstrap for the WHOOP MCP server on Debian 12 (GCP e2-micro).
+# Installs Node.js 22 + Caddy, creates the `whoop` service user, clones and
+# builds the server. Idempotent — safe to re-run. Contains NO secrets.
+#
+# Run on the VM as a sudo user:
+#   curl -fsSL https://raw.githubusercontent.com/codeOfJannik/whoop-mcp/main/docs/deploy/bootstrap-vm.sh | sudo bash
+# or copy it over and:  sudo bash bootstrap-vm.sh
+#
+# After it finishes, follow docs/deploy/gcp-e2-micro-duckdns.md from step 4
+# (drop in the env file, token, Caddyfile, and start the services).
+
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/codeOfJannik/whoop-mcp.git}"
+APP_DIR="/opt/whoop-mcp"
+SVC_USER="whoop"
+
+echo "==> Installing base packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y curl git ca-certificates gnupg debian-keyring debian-archive-keyring apt-transport-https
+
+echo "==> Installing Node.js 22 (NodeSource)"
+if ! command -v node >/dev/null 2>&1 || [ "$(node -v | cut -d. -f1 | tr -d v)" -lt 20 ]; then
+	curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+	apt-get install -y nodejs
+fi
+node -v
+
+echo "==> Installing Caddy (official apt repo)"
+if ! command -v caddy >/dev/null 2>&1; then
+	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+		| gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+		| tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+	apt-get update -y
+	apt-get install -y caddy
+fi
+
+echo "==> Creating service user '${SVC_USER}'"
+if ! id "${SVC_USER}" >/dev/null 2>&1; then
+	useradd --system --create-home --home-dir "/home/${SVC_USER}" --shell /usr/sbin/nologin "${SVC_USER}"
+fi
+install -d -m 700 -o "${SVC_USER}" -g "${SVC_USER}" "/home/${SVC_USER}/.whoop-mcp"
+
+echo "==> Cloning / updating ${REPO_URL} into ${APP_DIR}"
+if [ -d "${APP_DIR}/.git" ]; then
+	git -C "${APP_DIR}" pull --ff-only
+else
+	git clone --depth 1 "${REPO_URL}" "${APP_DIR}"
+fi
+
+echo "==> Building"
+cd "${APP_DIR}"
+npm ci
+npm run build
+npm prune --omit=dev
+chown -R "${SVC_USER}:${SVC_USER}" "${APP_DIR}"
+
+echo "==> Creating /etc/whoop-mcp"
+install -d -m 750 -o root -g "${SVC_USER}" /etc/whoop-mcp
+
+cat <<'DONE'
+
+==> Base install complete.
+
+Next (see docs/deploy/gcp-e2-micro-duckdns.md, from step 4):
+  1. Copy your seeded WHOOP token to /home/whoop/.whoop-mcp/tokens.json
+       sudo install -m 600 -o whoop -g whoop tokens.json /home/whoop/.whoop-mcp/tokens.json
+  2. Create /etc/whoop-mcp/whoop-mcp.env from docs/deploy/whoop-mcp.env.example (chmod 600)
+  3. Install docs/deploy/whoop-mcp.service to /etc/systemd/system/ and enable it
+  4. Install docs/deploy/Caddyfile.example to /etc/caddy/Caddyfile (set your hostname), restart caddy
+  5. Set up the DuckDNS updater cron (docs/deploy/duckdns-update.sh)
+DONE

--- a/docs/deploy/duckdns-update.sh
+++ b/docs/deploy/duckdns-update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Point your DuckDNS subdomain at this VM's current public IP.
+#
+# Install to: /opt/whoop-mcp/duckdns-update.sh  (chmod 700, owned by whoop)
+# Fill in DUCKDNS_SUB and DUCKDNS_TOKEN below, then add a cron entry:
+#   */5 * * * * /opt/whoop-mcp/duckdns-update.sh >/dev/null 2>&1
+#
+# Leaving ip= empty tells DuckDNS to use the request's source IP (this VM's
+# public IP as seen through GCP's NAT), so it auto-tracks IP changes.
+
+set -euo pipefail
+
+DUCKDNS_SUB="YOURSUB"          # just the subdomain label, e.g. "whoop-jannik"
+DUCKDNS_TOKEN="your_duckdns_token"
+
+curl -fsS "https://www.duckdns.org/update?domains=${DUCKDNS_SUB}&token=${DUCKDNS_TOKEN}&ip=" \
+	-o /tmp/duckdns.log

--- a/docs/deploy/gcp-e2-micro-duckdns.md
+++ b/docs/deploy/gcp-e2-micro-duckdns.md
@@ -187,8 +187,12 @@ curl https://YOURSUB.duckdns.org/.well-known/oauth-authorization-server
   **budget alert at $1** so any accidental overage is visible.
 - **Logs:** `journalctl -u whoop-mcp -f` (server) and `journalctl -u caddy -f`
   (TLS). Secrets are redacted from server logs.
-- **Update the server:**
-  `cd /opt/whoop-mcp && sudo git pull && sudo npm ci && sudo npm run build && sudo npm prune --omit=dev && sudo systemctl restart whoop-mcp`
+- **Update the server:** run the deploy script — it pulls, rebuilds `dist/`,
+  restarts the service, and health-checks the WHOOP upstream in one step:
+  `curl -fsSL https://raw.githubusercontent.com/codeOfJannik/whoop-mcp/main/docs/deploy/update.sh | sudo bash`
+  (or `sudo bash /opt/whoop-mcp/docs/deploy/update.sh`). A bare `git pull` does
+  **not** deploy: the service runs the compiled `dist/`, so without a rebuild +
+  restart the old code keeps running.
 - **Token expiry:** if WHOOP ever fully revokes the refresh token, the service
   will fail to start (it can't run a headless browser flow). Re-seed with
   step 1 locally and re-copy `tokens.json` (step 4).

--- a/docs/deploy/gcp-e2-micro-duckdns.md
+++ b/docs/deploy/gcp-e2-micro-duckdns.md
@@ -1,0 +1,198 @@
+# Hosting WHOOP MCP for free on a GCP e2-micro VM (Caddy + DuckDNS)
+
+This runs the server always-on for **~$0/month** using Google Cloud's
+perpetual **Always Free** `e2-micro` instance, with free TLS from
+**Caddy + Let's Encrypt** and a free **DuckDNS** hostname. It's reachable by
+**claude.ai web and mobile** via the OAuth 2.1 connector.
+
+```
+claude.ai (web/mobile)
+      │  https://YOURSUB.duckdns.org/mcp   (OAuth 2.1 + PKCE, JWT bearer)
+      ▼
+  Caddy :443  ──reverse_proxy──▶  node dist/index.js  @ 127.0.0.1:3000
+  (Let's Encrypt cert)                     │
+                                           ▼
+                                   api.prod.whoop.com  (your WHOOP account)
+```
+
+**Why this shape is safe:** the Node server binds **loopback only**
+(`MCP_HOST=127.0.0.1`, the default). Nothing but Caddy can reach it, and only
+port 443 is ever exposed. Your `MCP_AUTH_TOKEN` and `MCP_CONNECTOR_PASSWORD`
+are the gate — anyone holding either can read all your WHOOP data, so treat
+them as high-value secrets.
+
+---
+
+## Prerequisites
+
+- The [`gcloud` CLI](https://cloud.google.com/sdk/docs/install) installed and
+  authenticated (`gcloud auth login`), with a project + **billing account**
+  attached (required even for Always Free; overages bill — set a budget alert).
+- A free [DuckDNS](https://www.duckdns.org) account: create a subdomain (e.g.
+  `whoop-jannik`) and copy your **token**.
+- Your WHOOP developer app (developer.whoop.com) with redirect URI
+  `http://localhost:3000/callback` (used only for the one-time local token
+  seed in step 1).
+- This fork: `https://github.com/codeOfJannik/whoop-mcp`.
+
+Pick a free-tier region for every command below: `us-west1`, `us-central1`,
+or `us-east1`. This guide uses `us-central1` / zone `us-central1-a`.
+
+---
+
+## Step 1 — Seed the WHOOP token locally (one time)
+
+The WHOOP OAuth grant needs a browser, which a headless VM doesn't have. Do it
+once on your laptop; the resulting refresh token is portable to the VM.
+
+```bash
+git clone https://github.com/codeOfJannik/whoop-mcp.git
+cd whoop-mcp && npm ci && npm run build
+
+WHOOP_CLIENT_ID=your_id \
+WHOOP_CLIENT_SECRET=your_secret \
+node dist/index.js
+# → a browser opens; authorize WHOOP.
+# → wait for "Authentication successful." then Ctrl-C.
+```
+
+This writes `~/.whoop-mcp/tokens.json`. Keep it handy for step 4.
+
+> The server refreshes this token automatically (no browser needed) as long as
+> **only one instance** uses it. Don't run the server locally again once the VM
+> is live, or refresh-token rotation will invalidate the VM's copy.
+
+---
+
+## Step 2 — Create the VM + firewall
+
+```bash
+# Always-Free e2-micro, 30 GB standard disk, Debian 12
+gcloud compute instances create whoop-mcp \
+  --zone=us-central1-a \
+  --machine-type=e2-micro \
+  --image-family=debian-12 --image-project=debian-cloud \
+  --boot-disk-size=30GB --boot-disk-type=pd-standard \
+  --tags=whoop-mcp
+
+# Allow HTTP (ACME challenge) + HTTPS from anywhere
+gcloud compute firewall-rules create whoop-mcp-web \
+  --network=default --direction=INGRESS --action=ALLOW \
+  --rules=tcp:80,tcp:443 --source-ranges=0.0.0.0/0 --target-tags=whoop-mcp
+```
+
+Note the VM's external IP:
+
+```bash
+gcloud compute instances describe whoop-mcp --zone=us-central1-a \
+  --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+```
+
+Point your DuckDNS subdomain at that IP once now (the cron in step 5 keeps it
+current): visit `https://www.duckdns.org/update?domains=YOURSUB&token=YOURTOKEN&ip=THAT_IP`.
+
+---
+
+## Step 3 — Bootstrap the VM (Node + Caddy + build)
+
+SSH in and run the bootstrap script (installs Node 22 + Caddy, creates the
+`whoop` user, clones + builds the repo):
+
+```bash
+gcloud compute ssh whoop-mcp --zone=us-central1-a
+
+# on the VM:
+curl -fsSL https://raw.githubusercontent.com/codeOfJannik/whoop-mcp/main/docs/deploy/bootstrap-vm.sh | sudo bash
+```
+
+---
+
+## Step 4 — Install the token, env file, and systemd unit
+
+Copy the token you seeded in step 1 up to the VM (from your laptop):
+
+```bash
+gcloud compute scp ~/.whoop-mcp/tokens.json whoop-mcp:/tmp/tokens.json --zone=us-central1-a
+```
+
+Back on the VM:
+
+```bash
+sudo install -m 600 -o whoop -g whoop /tmp/tokens.json /home/whoop/.whoop-mcp/tokens.json && rm /tmp/tokens.json
+
+# Env file — copy the template and fill in your secrets
+sudo cp /opt/whoop-mcp/docs/deploy/whoop-mcp.env.example /etc/whoop-mcp/whoop-mcp.env
+sudo chmod 600 /etc/whoop-mcp/whoop-mcp.env
+sudo nano /etc/whoop-mcp/whoop-mcp.env      # set WHOOP creds, PUBLIC_URL, and:
+#   MCP_AUTH_TOKEN="$(openssl rand -hex 32)"
+#   MCP_CONNECTOR_PASSWORD="$(openssl rand -base64 24)"
+#   PUBLIC_URL=https://YOURSUB.duckdns.org
+
+# systemd service
+sudo cp /opt/whoop-mcp/docs/deploy/whoop-mcp.service /etc/systemd/system/whoop-mcp.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now whoop-mcp
+sudo systemctl status whoop-mcp --no-pager     # should be active (running)
+journalctl -u whoop-mcp -n 30 --no-pager       # look for "http transport listening"
+```
+
+---
+
+## Step 5 — Caddy (TLS) + DuckDNS updater
+
+```bash
+# Caddy: set your hostname and reload
+sudo cp /opt/whoop-mcp/docs/deploy/Caddyfile.example /etc/caddy/Caddyfile
+sudo nano /etc/caddy/Caddyfile                 # replace YOURSUB.duckdns.org with your real hostname
+sudo systemctl restart caddy
+journalctl -u caddy -n 30 --no-pager           # look for "certificate obtained successfully"
+
+# DuckDNS auto-updater (keeps the hostname pointed at this VM)
+sudo cp /opt/whoop-mcp/docs/deploy/duckdns-update.sh /opt/whoop-mcp/duckdns-update.sh
+sudo nano /opt/whoop-mcp/duckdns-update.sh      # set DUCKDNS_SUB + DUCKDNS_TOKEN
+sudo chmod 700 /opt/whoop-mcp/duckdns-update.sh && sudo chown whoop:whoop /opt/whoop-mcp/duckdns-update.sh
+( sudo crontab -u whoop -l 2>/dev/null; echo "*/5 * * * * /opt/whoop-mcp/duckdns-update.sh >/dev/null 2>&1" ) | sudo crontab -u whoop -
+sudo -u whoop /opt/whoop-mcp/duckdns-update.sh  # run once now; should print "OK"
+```
+
+---
+
+## Step 6 — Verify
+
+```bash
+# From anywhere:
+curl https://YOURSUB.duckdns.org/health
+# → {"status":"ok"}
+
+# OAuth metadata is published (proves the connector is mounted):
+curl https://YOURSUB.duckdns.org/.well-known/oauth-authorization-server
+# → JSON with "issuer":"https://YOURSUB.duckdns.org"
+```
+
+---
+
+## Step 7 — Connect claude.ai
+
+1. claude.ai → **Settings → Connectors → Add custom connector**.
+2. URL: `https://YOURSUB.duckdns.org/mcp`.
+3. When prompted, enter your **`MCP_CONNECTOR_PASSWORD`**.
+4. Approve. Claude (web + mobile) now queries your WHOOP data.
+
+---
+
+## Operations & cost notes
+
+- **Cost:** e2-micro + 30 GB pd-standard + Caddy + DuckDNS all sit inside the
+  Always Free limits (1 GB/month egress is plenty for personal use). Set a GCP
+  **budget alert at $1** so any accidental overage is visible.
+- **Logs:** `journalctl -u whoop-mcp -f` (server) and `journalctl -u caddy -f`
+  (TLS). Secrets are redacted from server logs.
+- **Update the server:**
+  `cd /opt/whoop-mcp && sudo git pull && sudo npm ci && sudo npm run build && sudo npm prune --omit=dev && sudo systemctl restart whoop-mcp`
+- **Token expiry:** if WHOOP ever fully revokes the refresh token, the service
+  will fail to start (it can't run a headless browser flow). Re-seed with
+  step 1 locally and re-copy `tokens.json` (step 4).
+- **Rotating secrets:** change `MCP_AUTH_TOKEN` / `MCP_CONNECTOR_PASSWORD` in
+  the env file and `sudo systemctl restart whoop-mcp`; then reconnect in
+  claude.ai. Rotating `MCP_AUTH_TOKEN` also rotates the connector's JWT signing
+  key, so existing claude.ai sessions must re-authorize.

--- a/docs/deploy/update.sh
+++ b/docs/deploy/update.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Update an already-bootstrapped WHOOP MCP VM to the latest committed code.
+# Pulls, reinstalls deps, rebuilds dist/, restarts the service, and verifies
+# the upstream WHOOP API is reachable. Idempotent — safe to re-run. No secrets.
+#
+# Why this exists: `git pull` alone does NOT deploy. The service runs the
+# COMPILED dist/ under a long-lived process, so a pull without `npm run build`
+# + `systemctl restart` leaves the old code running indefinitely. This script
+# does all three (plus a health check) so an update can't half-land.
+#
+# Run on the VM as a sudo user:
+#   curl -fsSL https://raw.githubusercontent.com/codeOfJannik/whoop-mcp/main/docs/deploy/update.sh | sudo bash
+# or copy it over and:  sudo bash update.sh
+
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/opt/whoop-mcp}"
+SVC_USER="${SVC_USER:-whoop}"
+SERVICE="${SERVICE:-whoop-mcp}"
+ENV_FILE="${ENV_FILE:-/etc/whoop-mcp/whoop-mcp.env}"
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "ERROR: run as root (sudo bash update.sh)." >&2
+	exit 1
+fi
+
+if [ ! -d "${APP_DIR}/.git" ]; then
+	echo "ERROR: ${APP_DIR} is not a git checkout. Run bootstrap-vm.sh first." >&2
+	exit 1
+fi
+
+echo "==> Fetching latest code in ${APP_DIR}"
+cd "${APP_DIR}"
+BEFORE="$(git rev-parse --short HEAD)"
+git pull --ff-only
+AFTER="$(git rev-parse --short HEAD)"
+echo "    ${BEFORE} -> ${AFTER}"
+
+echo "==> Installing deps + building (dev deps needed for tsc)"
+npm ci
+npm run build
+# Trim back to runtime-only deps so the service stays lean, matching bootstrap.
+npm prune --omit=dev
+chown -R "${SVC_USER}:${SVC_USER}" "${APP_DIR}"
+
+echo "==> Restarting ${SERVICE}"
+systemctl restart "${SERVICE}"
+
+# Give the process a moment to authenticate + bind before probing.
+sleep 4
+
+echo "==> Service state"
+if ! systemctl is-active --quiet "${SERVICE}"; then
+	echo "ERROR: ${SERVICE} is not active after restart. Recent logs:" >&2
+	journalctl -u "${SERVICE}" -n 30 --no-pager >&2
+	exit 1
+fi
+systemctl is-active "${SERVICE}"
+
+# Health check: hit the authed /health endpoint, which makes a real WHOOP API
+# call and reports upstream reachability as whoopApi: "ok" | "error".
+echo "==> Verifying WHOOP upstream via /health"
+if [ -r "${ENV_FILE}" ]; then
+	# shellcheck disable=SC1090
+	set -a
+	. "${ENV_FILE}"
+	set +a
+	PORT="${MCP_PORT:-3000}"
+	HEALTH="$(curl -fsS -H "Authorization: Bearer ${MCP_AUTH_TOKEN:-}" \
+		"http://127.0.0.1:${PORT}/health" 2>/dev/null || true)"
+	echo "    ${HEALTH:-<no response>}"
+	case "${HEALTH}" in
+		*'"whoopApi":"ok"'*)
+			echo "==> Update complete — WHOOP API reachable."
+			;;
+		*)
+			echo "WARNING: server is up but WHOOP API is not confirmed reachable." >&2
+			echo "  If startup logged 'interactive OAuth is disabled', the stored" >&2
+			echo "  refresh token is dead — re-seed /home/${SVC_USER}/.whoop-mcp/tokens.json" >&2
+			echo "  (see docs/deploy/gcp-e2-micro-duckdns.md) and restart." >&2
+			journalctl -u "${SERVICE}" -n 15 --no-pager >&2
+			exit 1
+			;;
+	esac
+else
+	echo "    ${ENV_FILE} not readable — skipping health check."
+	echo "==> Update complete (service restarted; health not verified)."
+fi

--- a/docs/deploy/whoop-mcp.env.example
+++ b/docs/deploy/whoop-mcp.env.example
@@ -1,0 +1,35 @@
+# WHOOP MCP server — runtime environment for the systemd service.
+#
+# Install to: /etc/whoop-mcp/whoop-mcp.env   (chmod 600, owned by root)
+# This file holds secrets — never commit a filled-in copy.
+
+# --- WHOOP developer app credentials (from developer.whoop.com) ---
+WHOOP_CLIENT_ID=your_whoop_client_id
+WHOOP_CLIENT_SECRET=your_whoop_client_secret
+
+# --- Transport ---
+MCP_TRANSPORT=http
+# Bind loopback only. Caddy (on this same VM) reverse-proxies to it, so the
+# server is never directly exposed. Do NOT set this to 0.0.0.0 here.
+MCP_HOST=127.0.0.1
+MCP_PORT=3000
+
+# --- Auth secrets ---
+# Admin bearer for /mcp AND the seed for the connector's JWT key. >= 32 chars.
+#   openssl rand -hex 32
+MCP_AUTH_TOKEN=replace_me_with_openssl_rand_hex_32
+# Password you type into the claude.ai connector dialog. >= 12 chars.
+#   openssl rand -base64 24
+MCP_CONNECTOR_PASSWORD=replace_me_with_openssl_rand_base64_24
+
+# --- OAuth 2.1 connector (for claude.ai web/mobile) ---
+# Public https origin claude.ai will reach — your DuckDNS hostname.
+PUBLIC_URL=https://YOURSUB.duckdns.org
+ALLOWED_REDIRECT_URIS=https://claude.ai/api/mcp/auth_callback
+
+# --- Behind Caddy (a trusted reverse proxy) ---
+MCP_TRUST_PROXY=1
+
+# --- Logging ---
+LOG_LEVEL=info
+LOG_FORMAT=json

--- a/docs/deploy/whoop-mcp.service
+++ b/docs/deploy/whoop-mcp.service
@@ -1,0 +1,35 @@
+# WHOOP MCP server — systemd unit (HTTP transport).
+#
+# Install to: /etc/systemd/system/whoop-mcp.service
+# Then:  sudo systemctl daemon-reload && sudo systemctl enable --now whoop-mcp
+
+[Unit]
+Description=WHOOP MCP server (HTTP transport)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=whoop
+Group=whoop
+# os.homedir() resolves the WHOOP token path (~/.whoop-mcp/tokens.json) from HOME.
+Environment=HOME=/home/whoop
+WorkingDirectory=/opt/whoop-mcp
+EnvironmentFile=/etc/whoop-mcp/whoop-mcp.env
+ExecStart=/usr/bin/node /opt/whoop-mcp/dist/index.js
+Restart=always
+RestartSec=3
+
+# --- Hardening ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=false
+# The only path the service must write to is the token store.
+ReadWritePaths=/home/whoop/.whoop-mcp
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "whoop-ai-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "whoop-ai-mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
+        "jose": "^6.2.2",
         "zod": "^4.4.3"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whoop-ai-mcp",
-  "version": "0.6.0",
-  "mcpName": "io.github.shashankswe2020-ux/whoop",
+  "version": "0.7.0",
+  "mcpName": "io.github.codeOfJannik/whoop",
   "description": "MCP server wrapping the WHOOP REST API for AI assistant access to health and fitness data",
   "type": "module",
   "main": "dist/index.js",
@@ -35,21 +35,27 @@
     "ai",
     "claude"
   ],
-  "author": "Shashank Mishra",
+  "author": "Jannik Schlemmer",
+  "contributors": [
+    "Shashank Mishra (original author)"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shashankswe2020-ux/whoop-mcp.git"
+    "url": "git+https://github.com/codeOfJannik/whoop-mcp.git"
   },
-  "homepage": "https://github.com/shashankswe2020-ux/whoop-mcp#readme",
+  "homepage": "https://github.com/codeOfJannik/whoop-mcp#readme",
   "bugs": {
-    "url": "https://github.com/shashankswe2020-ux/whoop-mcp/issues"
+    "url": "https://github.com/codeOfJannik/whoop-mcp/issues"
   },
   "engines": {
     "node": ">=20.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
+    "jose": "^6.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.shashankswe2020-ux/whoop",
+  "name": "io.github.codeOfJannik/whoop",
   "description": "MCP server for WHOOP health data — recovery, sleep, workouts, cycles, and trends.",
   "repository": {
-    "url": "https://github.com/shashankswe2020-ux/whoop-mcp",
+    "url": "https://github.com/codeOfJannik/whoop-mcp",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "whoop-ai-mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -168,8 +168,41 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
   const requestId = options.requestId;
   const cache = options.cache;
 
+  // Mutable, factory-scoped so a token refreshed on one request is reused by
+  // every subsequent request. Without this, each request keeps presenting the
+  // token captured at startup — which expires after ~1h — forcing a refresh on
+  // literally every call once that token lapses.
+  let currentAccessToken = options.accessToken;
+
+  // Single-flight guard: concurrent 401s share ONE refresh instead of each
+  // firing its own. WHOOP rotates refresh tokens (single-use), so parallel
+  // refreshes race — all but one present an already-consumed refresh token and
+  // fail, which can persist a dead token and break auth until process restart.
+  let refreshInFlight: Promise<string> | null = null;
+
   function logExtras(extra: Record<string, unknown>): Record<string, unknown> {
     return requestId !== undefined ? { requestId, ...extra } : extra;
+  }
+
+  /**
+   * Refresh the access token at most once concurrently. Callers that arrive
+   * while a refresh is in progress await the same result rather than starting
+   * a competing refresh. On success the new token is cached in
+   * `currentAccessToken` for all future requests.
+   */
+  async function refreshAccessToken(): Promise<string> {
+    if (refreshInFlight) return refreshInFlight;
+    const pending = (async (): Promise<string> => {
+      const token = await options.onTokenRefresh!();
+      currentAccessToken = token;
+      return token;
+    })();
+    refreshInFlight = pending;
+    try {
+      return await pending;
+    } finally {
+      if (refreshInFlight === pending) refreshInFlight = null;
+    }
   }
 
   async function doFetch(url: string, accessToken: string): Promise<Response> {
@@ -233,7 +266,6 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
 
   async function doGet<T>(path: string): Promise<T> {
     const url = `${baseUrl}${path}`;
-    let currentToken = options.accessToken;
     let lastError: WhoopApiError | undefined;
     let lastResponse: Response | undefined;
 
@@ -245,7 +277,10 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
         await delay(retryDelay);
       }
 
-      const response = await doFetch(url, currentToken);
+      // Snapshot the token used for this attempt so we can detect whether a
+      // concurrent request refreshed it out from under us on a 401.
+      const tokenForAttempt = currentAccessToken;
+      const response = await doFetch(url, tokenForAttempt);
 
       if (response.ok) {
         return (await response.json()) as T;
@@ -269,15 +304,20 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
       // 401: attempt token refresh once
       if (response.status === 401 && options.onTokenRefresh) {
         let newToken: string;
-        try {
-          newToken = await options.onTokenRefresh();
-          logger?.info("whoop token refreshed", logExtras({ url }));
-        } catch (refreshError: unknown) {
-          throw new WhoopAuthError(refreshError);
+        if (currentAccessToken !== tokenForAttempt) {
+          // A concurrent request already refreshed the token while this attempt
+          // was in flight — reuse it instead of firing a redundant refresh.
+          newToken = currentAccessToken;
+        } else {
+          try {
+            newToken = await refreshAccessToken();
+            logger?.info("whoop token refreshed", logExtras({ url }));
+          } catch (refreshError: unknown) {
+            throw new WhoopAuthError(refreshError);
+          }
         }
 
         // Retry with the new token
-        currentToken = newToken;
         const retryResponse = await doFetch(url, newToken);
         if (retryResponse.ok) {
           return (await retryResponse.json()) as T;

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -32,6 +32,14 @@ export interface OAuthConfig {
   tokenDir?: string;
   /** Callback server port. Default: 3000 */
   port?: number;
+  /**
+   * Whether the interactive browser OAuth flow may be launched as a last
+   * resort. Defaults to `true` (local stdio use). Set to `false` for headless
+   * server deployments (HTTP transport) where no browser exists — a missing or
+   * unrefreshable token then fails fast with an actionable error instead of
+   * silently hanging on a browser prompt that can never complete.
+   */
+  allowInteractive?: boolean;
 }
 
 /** Raw token response from the WHOOP token endpoint */
@@ -284,7 +292,19 @@ export async function authenticate(config: OAuthConfig): Promise<string> {
     console.error("No cached tokens found, starting OAuth flow...");
   }
 
-  // 3. Full OAuth flow
+  // 3. Full OAuth flow — but only if an interactive browser is available.
+  // Headless HTTP deployments have no browser: fail fast with guidance rather
+  // than hang forever waiting on a callback that will never arrive.
+  if (config.allowInteractive === false) {
+    throw new Error(
+      "WHOOP re-authentication is required, but interactive OAuth is disabled " +
+        "(headless HTTP mode). The stored token is missing or its refresh token " +
+        "is no longer valid. Run the WHOOP OAuth flow on a machine with a browser, " +
+        "then copy ~/.whoop-mcp/tokens.json to this host and restart the service.\n" +
+        "See: https://github.com/codeOfJannik/whoop-mcp#configuration"
+    );
+  }
+
   return performOAuthFlow(config);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { createWhoopClient } from "./api/client.js";
 import { MemoryCache } from "./cache/memory-cache.js";
 import { createWhoopServer } from "./server.js";
 import { connectStdioTransport } from "./transport/stdio.js";
-import { createHttpServer, type HttpServerResult } from "./transport/http.js";
+import { createHttpServer, safeTokenCompare, type HttpServerResult } from "./transport/http.js";
 import { createLogger, type LogLevel, type Logger } from "./logging/logger.js";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
@@ -35,6 +35,12 @@ import { realpathSync } from "node:fs";
 
 export type TransportMode = "stdio" | "http" | "both";
 
+/** Minimum MCP_AUTH_TOKEN length enforced in HTTP mode (128 bits hex = 32 chars). */
+const MIN_AUTH_TOKEN_LENGTH = 32;
+
+/** Host values that keep the server off the network (loopback only). */
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
 // ---------------------------------------------------------------------------
 // Env parsing helpers
 // ---------------------------------------------------------------------------
@@ -45,7 +51,7 @@ function getRequiredEnv(name: string): string {
     throw new Error(
       `Missing required environment variable: ${name}.\n` +
         `Set it in your Claude Desktop config or shell environment.\n` +
-        `See: https://github.com/shashankswe2020-ux/whoop-mcp#configuration`
+        `See: https://github.com/codeOfJannik/whoop-mcp#configuration`
     );
   }
   return value;
@@ -157,10 +163,29 @@ export async function main(): Promise<void> {
 
   if (transportMode === "http" || transportMode === "both") {
     const authToken = getRequiredEnv("MCP_AUTH_TOKEN");
+    // MCP_AUTH_TOKEN is both the admin bearer for /mcp AND the seed the OAuth
+    // connector's JWT signing key is HKDF-derived from (public salt/info), so
+    // a weak value makes connector access tokens forgeable. Enforce entropy.
+    if (authToken.length < MIN_AUTH_TOKEN_LENGTH) {
+      throw new Error(
+        `MCP_AUTH_TOKEN must be at least ${MIN_AUTH_TOKEN_LENGTH} characters when using the HTTP transport ` +
+          `(got ${authToken.length}). Generate one with: openssl rand -hex 32`
+      );
+    }
     const port = parsePort();
-    const host = process.env.MCP_HOST ?? "0.0.0.0";
+    const host = process.env.MCP_HOST ?? "127.0.0.1";
     const allowedOrigins = parseAllowedOrigins();
     const trustProxy = process.env.MCP_TRUST_PROXY === "1";
+
+    // Binding to anything other than loopback exposes your WHOOP data on the
+    // network — only safe behind a TLS-terminating proxy + firewall (e.g. a
+    // container platform). Warn loudly so an accidental LAN bind is visible.
+    if (!LOOPBACK_HOSTS.has(host)) {
+      logger.warn(
+        "http transport binding to a non-loopback interface — ensure it is firewalled and fronted by TLS",
+        { host }
+      );
+    }
 
     // Lightweight upstream WHOOP health probe used by GET /health (authed).
     const healthCheck = async (): Promise<boolean> => {
@@ -181,6 +206,9 @@ export async function main(): Promise<void> {
           res: import("node:http").ServerResponse
         ) => void)
       | undefined;
+    // When the connector is mounted, /mcp must accept its JWT access tokens in
+    // addition to the static admin bearer. Left undefined otherwise (static only).
+    let verifyBearer: ((token: string) => Promise<boolean>) | undefined;
     const connectorPassword = process.env.MCP_CONNECTOR_PASSWORD;
     const publicUrl = process.env.PUBLIC_URL;
     const allowedRedirectUris = process.env.ALLOWED_REDIRECT_URIS;
@@ -211,6 +239,20 @@ export async function main(): Promise<void> {
         res: import("node:http").ServerResponse
       ) => void;
       oauthCloseFn = oauthApp.close;
+
+      // Accept the static admin bearer OR a valid connector-issued JWT so
+      // claude.ai web/mobile clients can reach /mcp after the OAuth flow.
+      const provider = oauthApp.provider;
+      verifyBearer = async (token: string): Promise<boolean> => {
+        if (safeTokenCompare(token, authToken)) return true;
+        try {
+          await provider.verifyAccessToken(token);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
       logger.info("oauth connector mounted", { publicUrl });
     }
 
@@ -222,6 +264,7 @@ export async function main(): Promise<void> {
       trustProxy,
       healthCheck,
       oauthHandler,
+      ...(verifyBearer !== undefined && { verifyBearer }),
     });
     await server.connect(httpResult.transport);
     httpResults.push(httpResult);

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,14 +151,17 @@ export async function main(): Promise<void> {
 
   // 5. Create the MCP server with all WHOOP tools and resources
   const disableResources = process.env.WHOOP_MCP_DISABLE_RESOURCES === "1";
-  const { server } = createWhoopServer(client, { disableResources });
+  // Factory so the HTTP transport can build a fresh, stateless MCP server per
+  // request (required for clients like claude.ai that re-initialize each turn).
+  const createMcpServer = (): ReturnType<typeof createWhoopServer>["server"] =>
+    createWhoopServer(client, { disableResources }).server;
 
   // 6. Connect transports based on MCP_TRANSPORT mode
   const httpResults: HttpServerResult[] = [];
   let oauthCloseFn: (() => void) | null = null;
 
   if (transportMode === "stdio" || transportMode === "both") {
-    await connectStdioTransport(server);
+    await connectStdioTransport(createMcpServer());
   }
 
   if (transportMode === "http" || transportMode === "both") {
@@ -264,9 +267,9 @@ export async function main(): Promise<void> {
       trustProxy,
       healthCheck,
       oauthHandler,
+      createMcpServer,
       ...(verifyBearer !== undefined && { verifyBearer }),
     });
-    await server.connect(httpResult.transport);
     httpResults.push(httpResult);
 
     logger.info("http transport listening", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,14 @@ export async function main(): Promise<void> {
   // 2. Read WHOOP OAuth credentials (always required)
   const clientId = getRequiredEnv("WHOOP_CLIENT_ID");
   const clientSecret = getRequiredEnv("WHOOP_CLIENT_SECRET");
-  const oauthConfig: OAuthConfig = { clientId, clientSecret };
+  // Pure HTTP transport is a headless server: no browser for the interactive
+  // OAuth fallback. Disable it so a stale token chain fails fast with guidance
+  // instead of hanging on a callback that can never complete.
+  const oauthConfig: OAuthConfig = {
+    clientId,
+    clientSecret,
+    allowInteractive: transportMode !== "http",
+  };
 
   // 3. Authenticate with WHOOP — uses cached tokens, refreshes, or runs full flow
   console.error("Authenticating with WHOOP...");

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -11,6 +11,7 @@ import { createServer, type IncomingMessage, type ServerResponse, type Server } 
 import { createHash, timingSafeEqual } from "node:crypto";
 import { randomUUID } from "node:crypto";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,11 +65,29 @@ export interface HttpServerOptions {
    * because JWT verification is async.
    */
   verifyBearer?: (token: string) => boolean | Promise<boolean>;
+  /**
+   * Factory that builds a fresh MCP server for EACH /mcp request.
+   *
+   * When provided, the transport runs in **stateless** mode: every request gets
+   * a new server + `sessionIdGenerator: undefined` transport, so clients that
+   * re-`initialize` on every turn without reusing a session ID (e.g. claude.ai
+   * web/mobile) work correctly. A single stateful transport would reject the
+   * 2nd+ `initialize` with 400.
+   *
+   * When omitted, the server falls back to a single shared stateful transport
+   * exposed as {@link HttpServerResult.transport} (used by embedding tests that
+   * connect their own MCP server).
+   */
+  createMcpServer?: () => McpServer;
 }
 
 export interface HttpServerResult {
   server: Server;
-  transport: StreamableHTTPServerTransport;
+  /**
+   * The shared stateful transport — present ONLY when `createMcpServer` was not
+   * supplied (legacy/embedding path). Undefined in stateless mode.
+   */
+  transport?: StreamableHTTPServerTransport;
   /** Gracefully close the server and drain connections */
   close: () => Promise<void>;
 }
@@ -201,6 +220,7 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
     mcpRateLimit = { windowMs: 60_000, max: 100 },
     sseReauthIntervalMs = 5 * 60 * 1000,
     verifyBearer,
+    createMcpServer,
   } = options;
 
   if (!authToken) {
@@ -264,10 +284,11 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
     sseTimer.unref();
   }
 
-  // Create the SDK transport (stateful with session IDs)
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-  });
+  // Legacy shared stateful transport — only when no per-request factory is
+  // supplied. In production `createMcpServer` is always set (stateless mode).
+  const sharedTransport = createMcpServer
+    ? undefined
+    : new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
 
   // Create HTTP server
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
@@ -363,9 +384,26 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
         }
       }
 
-      // Delegate to SDK transport
+      // Delegate to an MCP transport.
       try {
-        await transport.handleRequest(req, res, parsedBody);
+        if (createMcpServer) {
+          // Stateless per-request: a fresh server + session-less transport per
+          // request means a repeated `initialize` (as claude.ai sends every
+          // turn, with no Mcp-Session-Id) always hits a clean slate instead of
+          // being rejected with 400 by a carried-over session.
+          const perRequestServer = createMcpServer();
+          const perRequestTransport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+          });
+          res.on("close", () => {
+            void perRequestTransport.close();
+            void perRequestServer.close();
+          });
+          await perRequestServer.connect(perRequestTransport);
+          await perRequestTransport.handleRequest(req, res, parsedBody);
+        } else {
+          await sharedTransport!.handleRequest(req, res, parsedBody);
+        }
       } catch (error: unknown) {
         // If response hasn't been sent yet
         if (!res.headersSent) {
@@ -393,7 +431,9 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
       clearInterval(sseTimer);
       sseTimer = null;
     }
-    await transport.close();
+    if (sharedTransport) {
+      await sharedTransport.close();
+    }
     await new Promise<void>((resolve, reject) => {
       server.close((err) => {
         if (err) reject(err);
@@ -402,5 +442,5 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
     });
   };
 
-  return { server, transport, close };
+  return { server, transport: sharedTransport, close };
 }

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -21,7 +21,7 @@ export interface HttpServerOptions {
   authToken: string;
   /** Port to listen on (0 = dynamic, used in tests) */
   port: number;
-  /** Hostname to bind to (default: 0.0.0.0) */
+  /** Hostname to bind to (default: 127.0.0.1 — loopback, safe by default) */
   host?: string;
   /** Maximum concurrent connections (default: 5) */
   maxConnections?: number;
@@ -54,11 +54,16 @@ export interface HttpServerOptions {
    */
   sseReauthIntervalMs?: number;
   /**
-   * Optional bearer-token validator used by the SSE re-auth sweep. Defaults
-   * to a static comparison against `authToken` (never expires). Override to
-   * plug in OAuth JWT expiry checks.
+   * Bearer-token verifier for the /mcp route AND the SSE re-auth sweep.
+   *
+   * Defaults to a constant-time comparison against the static `authToken`
+   * (the admin bearer used by Claude Desktop / Claude Code). When the OAuth
+   * connector is mounted, `index.ts` overrides this with a verifier that
+   * ALSO accepts connector-issued JWT access tokens (so claude.ai web/mobile
+   * clients can reach /mcp after completing the OAuth flow). May be async
+   * because JWT verification is async.
    */
-  validateBearerToken?: (token: string) => boolean;
+  verifyBearer?: (token: string) => boolean | Promise<boolean>;
 }
 
 export interface HttpServerResult {
@@ -187,7 +192,7 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
   const {
     authToken,
     port,
-    host = "0.0.0.0",
+    host = "127.0.0.1",
     maxConnections = 5,
     allowedOrigins = [],
     trustProxy = false,
@@ -195,7 +200,7 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
     oauthHandler,
     mcpRateLimit = { windowMs: 60_000, max: 100 },
     sseReauthIntervalMs = 5 * 60 * 1000,
-    validateBearerToken,
+    verifyBearer,
   } = options;
 
   if (!authToken) {
@@ -204,6 +209,12 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
         "Set it to a secure random string (32+ characters recommended)."
     );
   }
+
+  // Default verifier: constant-time compare against the static admin bearer.
+  // index.ts overrides this to ALSO accept connector-issued JWTs when the
+  // OAuth connector is mounted.
+  const verifyBearerToken =
+    verifyBearer ?? ((t: string): boolean => safeTokenCompare(t, authToken));
 
   // Track active connections for limiting
   let activeConnections = 0;
@@ -240,13 +251,14 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
   let sseTimer: NodeJS.Timeout | null = null;
   if (sseReauthIntervalMs > 0) {
     sseTimer = setInterval(() => {
-      const validate =
-        validateBearerToken ?? ((t: string): boolean => safeTokenCompare(t, authToken));
-      for (const c of sseConnections) {
-        if (!validate(c.token)) {
-          c.res.end();
-          sseConnections.delete(c);
-        }
+      // Snapshot to avoid mutating the Set while async checks are in flight.
+      for (const c of [...sseConnections]) {
+        void Promise.resolve(verifyBearerToken(c.token)).then((ok) => {
+          if (!ok) {
+            c.res.end();
+            sseConnections.delete(c);
+          }
+        });
       }
     }, sseReauthIntervalMs);
     sseTimer.unref();
@@ -303,9 +315,10 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
 
     // Route: /mcp (all methods)
     if (pathname === "/mcp") {
-      // Auth check
+      // Auth check — accepts the static admin bearer OR (when the OAuth
+      // connector is mounted) a valid connector-issued JWT access token.
       const token = extractBearerToken(req);
-      if (!token || !safeTokenCompare(token, authToken)) {
+      if (!token || !(await verifyBearerToken(token))) {
         sendJson(res, 401, { error: "Unauthorized" });
         return;
       }

--- a/src/transport/oauth-connector.ts
+++ b/src/transport/oauth-connector.ts
@@ -427,14 +427,35 @@ function renderPasswordPage(params: Record<string, string>, error?: string): str
 </html>`;
 }
 
+/**
+ * Build the CSP `form-action` value for the password page: `'self'` (the POST
+ * target) plus the distinct origins of the allowed redirect URIs.
+ *
+ * The authorize POST succeeds server-side and responds with a 302 back to the
+ * client's redirect_uri (e.g. https://claude.ai/api/mcp/auth_callback).
+ * Browsers enforce `form-action` across that redirect, so the redirect target's
+ * origin MUST be listed or the OAuth flow dies one step from completion.
+ */
+function formActionForRedirectUris(allowedRedirectUris: string[]): string {
+  const origins = new Set<string>();
+  for (const uri of allowedRedirectUris) {
+    try {
+      origins.add(new URL(uri).origin);
+    } catch {
+      // Ignore malformed entries — startup config is validated elsewhere.
+    }
+  }
+  return ["'self'", ...origins].join(" ");
+}
+
 /** Apply anti-clickjacking + tight CSP headers to the password-prompt response. */
-function applyAuthorizePageHeaders(res: Response): void {
+function applyAuthorizePageHeaders(res: Response, formAction: string): void {
   res.setHeader("Cache-Control", "no-store");
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("X-Frame-Options", "DENY");
   res.setHeader(
     "Content-Security-Policy",
-    "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'"
+    `default-src 'none'; style-src 'unsafe-inline'; form-action ${formAction}; frame-ancestors 'none'; base-uri 'none'`
   );
   res.setHeader("Referrer-Policy", "no-referrer");
   res.setHeader("X-Content-Type-Options", "nosniff");
@@ -488,6 +509,10 @@ export function createOAuthApp(options: CreateOAuthAppOptions): CreateOAuthAppRe
   validateConnectorPassword(options.connectorPassword);
   const publicUrl = validatePublicUrl(options.publicUrl);
 
+  // CSP form-action for the password page must permit the post-authorization
+  // redirect back to the client's redirect_uri origin (e.g. https://claude.ai).
+  const authorizePageFormAction = formActionForRedirectUris(options.allowedRedirectUris);
+
   const provider =
     options.provider ??
     new OAuthConnectorProvider({
@@ -527,7 +552,7 @@ export function createOAuthApp(options: CreateOAuthAppOptions): CreateOAuthAppRe
       const v = req.query[k];
       if (typeof v === "string") params[k] = v;
     }
-    applyAuthorizePageHeaders(res);
+    applyAuthorizePageHeaders(res, authorizePageFormAction);
     res.status(200).send(renderPasswordPage(params));
   });
 
@@ -546,7 +571,7 @@ export function createOAuthApp(options: CreateOAuthAppOptions): CreateOAuthAppRe
           const v = body[k];
           if (typeof v === "string") params[k] = v;
         }
-        applyAuthorizePageHeaders(res);
+        applyAuthorizePageHeaders(res, authorizePageFormAction);
         res.status(401).send(renderPasswordPage(params, "Incorrect password. Try again."));
         return;
       }

--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -643,6 +643,62 @@ describe("createWhoopClient", () => {
       await expect(client.get("/v2/recovery")).rejects.toThrow(WhoopApiError);
       expect(onTokenRefresh).not.toHaveBeenCalled();
     });
+
+    it("reuses the refreshed token on subsequent requests (no repeated refresh)", async () => {
+      const NEW_TOKEN = "refreshed_token_persisted";
+      // First request: expired token → 401 → refresh → success.
+      // Second request: must use the cached NEW_TOKEN and NOT 401 / refresh again.
+      mockFetch
+        .mockResolvedValueOnce(mock401Response())
+        .mockResolvedValueOnce(mockJsonResponse({ ok: 1 }))
+        .mockResolvedValueOnce(mockJsonResponse({ ok: 2 }));
+      const onTokenRefresh = vi.fn().mockResolvedValue(NEW_TOKEN);
+      const client = createWhoopClient({
+        accessToken: TEST_TOKEN,
+        baseUrl: TEST_BASE_URL,
+        onTokenRefresh,
+      });
+
+      await client.get("/v2/recovery");
+      await client.get("/v2/sleep");
+
+      // Refreshed exactly once across both requests.
+      expect(onTokenRefresh).toHaveBeenCalledOnce();
+      // 3 fetches total: 401, retry, then the second request's single call.
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      // The second request used the refreshed token directly.
+      const secondReqCall = mockFetch.mock.calls[2] as [string, RequestInit];
+      expect(secondReqCall[1].headers).toEqual(
+        expect.objectContaining({ Authorization: `Bearer ${NEW_TOKEN}` })
+      );
+    });
+
+    it("coalesces concurrent 401s into a single token refresh", async () => {
+      const NEW_TOKEN = "refreshed_token_shared";
+      // Two concurrent requests each get a 401 on their first fetch, then succeed.
+      mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+        const auth = (init.headers as Record<string, string>).Authorization;
+        if (auth === `Bearer ${NEW_TOKEN}`) {
+          return Promise.resolve(mockJsonResponse({ ok: true }));
+        }
+        return Promise.resolve(mock401Response());
+      });
+      // Refresh is async; both requests should latch onto the same in-flight call.
+      const onTokenRefresh = vi.fn(
+        () => new Promise<string>((r) => setTimeout(() => r(NEW_TOKEN), 10))
+      );
+      const client = createWhoopClient({
+        accessToken: TEST_TOKEN,
+        baseUrl: TEST_BASE_URL,
+        onTokenRefresh,
+      });
+
+      await Promise.all([client.get("/v2/recovery"), client.get("/v2/sleep")]);
+
+      // Both concurrent 401s shared ONE refresh — critical for WHOOP's
+      // single-use rotating refresh tokens.
+      expect(onTokenRefresh).toHaveBeenCalledOnce();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/tests/auth/oauth.test.ts
+++ b/tests/auth/oauth.test.ts
@@ -771,6 +771,32 @@ describe("authenticate", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
+  it("fails fast (no browser) when no tokens exist and interactive is disabled", async () => {
+    mockLoadTokens.mockResolvedValueOnce(null);
+
+    await expect(
+      authenticate({ ...TEST_CONFIG, allowInteractive: false })
+    ).rejects.toThrow(/interactive OAuth is disabled/i);
+    expect(mockStartCallbackServer).not.toHaveBeenCalled();
+  });
+
+  it("fails fast (no browser) when refresh fails and interactive is disabled", async () => {
+    const expiredTokens: OAuthTokens = { ...VALID_TOKENS, expires_at: Date.now() - 1000 };
+    mockLoadTokens.mockResolvedValueOnce(expiredTokens);
+    mockIsTokenExpired.mockReturnValueOnce(true);
+    // Refresh fetch fails with invalid_grant (dead refresh chain).
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ error: "invalid_grant" }),
+    });
+
+    await expect(
+      authenticate({ ...TEST_CONFIG, allowInteractive: false })
+    ).rejects.toThrow(/interactive OAuth is disabled/i);
+    expect(mockStartCallbackServer).not.toHaveBeenCalled();
+  });
+
   it("throws a clear error if clientId is missing", async () => {
     const badConfig = { ...TEST_CONFIG, clientId: "" };
     await expect(authenticate(badConfig)).rejects.toThrow(/WHOOP_CLIENT_ID|client.*id/i);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -418,7 +418,7 @@ describe("main() entry point", () => {
 
     it("MCP_TRANSPORT=http starts only the HTTP server (no stdio)", async () => {
       process.env.MCP_TRANSPORT = "http";
-      process.env.MCP_AUTH_TOKEN = "test-bearer-token-32chars-aaaa";
+      process.env.MCP_AUTH_TOKEN = "test-bearer-token-0123456789abcdef";
       process.env.MCP_PORT = "4001";
       setupHappyPath();
       setupHttpHappyPath();
@@ -430,7 +430,7 @@ describe("main() entry point", () => {
       expect(mockCreateHttpServer).toHaveBeenCalledOnce();
       expect(mockCreateHttpServer).toHaveBeenCalledWith(
         expect.objectContaining({
-          authToken: "test-bearer-token-32chars-aaaa",
+          authToken: "test-bearer-token-0123456789abcdef",
           port: 4001,
         })
       );
@@ -440,7 +440,7 @@ describe("main() entry point", () => {
 
     it("MCP_TRANSPORT=both starts both stdio AND HTTP", async () => {
       process.env.MCP_TRANSPORT = "both";
-      process.env.MCP_AUTH_TOKEN = "test-bearer-token-32chars-aaaa";
+      process.env.MCP_AUTH_TOKEN = "test-bearer-token-0123456789abcdef";
       setupHappyPath();
       setupHttpHappyPath();
 
@@ -455,7 +455,7 @@ describe("main() entry point", () => {
 
     it("uses default port 3000 when MCP_PORT is unset", async () => {
       process.env.MCP_TRANSPORT = "http";
-      process.env.MCP_AUTH_TOKEN = "tok";
+      process.env.MCP_AUTH_TOKEN = "test-bearer-token-0123456789abcdef";
       setupHappyPath();
       setupHttpHappyPath();
 
@@ -467,7 +467,7 @@ describe("main() entry point", () => {
 
     it("forwards MCP_HOST and MCP_ALLOWED_ORIGINS to the HTTP server", async () => {
       process.env.MCP_TRANSPORT = "http";
-      process.env.MCP_AUTH_TOKEN = "tok";
+      process.env.MCP_AUTH_TOKEN = "test-bearer-token-0123456789abcdef";
       process.env.MCP_HOST = "127.0.0.1";
       process.env.MCP_ALLOWED_ORIGINS = "https://claude.ai, https://app.example.com";
       setupHappyPath();
@@ -486,7 +486,7 @@ describe("main() entry point", () => {
 
     it("MCP_TRUST_PROXY=1 enables trustProxy on the HTTP server", async () => {
       process.env.MCP_TRANSPORT = "http";
-      process.env.MCP_AUTH_TOKEN = "tok";
+      process.env.MCP_AUTH_TOKEN = "test-bearer-token-0123456789abcdef";
       process.env.MCP_TRUST_PROXY = "1";
       setupHappyPath();
       setupHttpHappyPath();
@@ -523,9 +523,18 @@ describe("main() entry point", () => {
       await expect(main()).rejects.toThrow(/MCP_AUTH_TOKEN/);
     });
 
+    it("throws when MCP_AUTH_TOKEN is shorter than 32 chars in http mode", async () => {
+      process.env.MCP_TRANSPORT = "http";
+      process.env.MCP_AUTH_TOKEN = "too-short-token";
+      setupHappyPath();
+
+      const { main } = await importMain();
+      await expect(main()).rejects.toThrow(/at least 32 characters/i);
+    });
+
     it("throws on non-numeric MCP_PORT", async () => {
       process.env.MCP_TRANSPORT = "http";
-      process.env.MCP_AUTH_TOKEN = "tok";
+      process.env.MCP_AUTH_TOKEN = "test-bearer-token-0123456789abcdef";
       process.env.MCP_PORT = "abc";
       setupHappyPath();
 
@@ -535,7 +544,7 @@ describe("main() entry point", () => {
 
     it("throws on out-of-range MCP_PORT", async () => {
       process.env.MCP_TRANSPORT = "http";
-      process.env.MCP_AUTH_TOKEN = "tok";
+      process.env.MCP_AUTH_TOKEN = "test-bearer-token-0123456789abcdef";
       process.env.MCP_PORT = "99999";
       setupHappyPath();
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -432,10 +432,12 @@ describe("main() entry point", () => {
         expect.objectContaining({
           authToken: "test-bearer-token-0123456789abcdef",
           port: 4001,
+          createMcpServer: expect.any(Function),
         })
       );
-      // server.connect was called with the http transport
-      expect(mockConnect).toHaveBeenCalledWith({ _http: true });
+      // HTTP builds a fresh per-request server internally, so the shared
+      // server.connect() is not used for the HTTP transport.
+      expect(mockConnect).not.toHaveBeenCalled();
     });
 
     it("MCP_TRANSPORT=both starts both stdio AND HTTP", async () => {
@@ -449,8 +451,8 @@ describe("main() entry point", () => {
 
       expect(MockStdioServerTransport).toHaveBeenCalledOnce();
       expect(mockCreateHttpServer).toHaveBeenCalledOnce();
-      // server.connect called for both transports
-      expect(mockConnect).toHaveBeenCalledTimes(2);
+      // Only stdio uses the shared server.connect(); HTTP builds per-request servers.
+      expect(mockConnect).toHaveBeenCalledTimes(1);
     });
 
     it("uses default port 3000 when MCP_PORT is unset", async () => {

--- a/tests/transport/http-mcp-integration.test.ts
+++ b/tests/transport/http-mcp-integration.test.ts
@@ -115,6 +115,54 @@ describe("HTTP transport — MCP integration", () => {
     expect(body.issuer).toMatch(/^https:\/\/example\.com\/?$/);
   });
 
+  it("stateless mode: repeated initialize + tool listing without a session id", async () => {
+    // Reproduces the claude.ai web/mobile pattern: a fresh `initialize` every
+    // turn, no Mcp-Session-Id reused. A single shared stateful transport rejects
+    // the 2nd initialize with 400; the per-request stateless factory must not.
+    const authToken = "test-bearer-token-0123456789abcdef";
+    const httpResult = await createHttpServer({
+      authToken,
+      port: 0,
+      createMcpServer: () => createWhoopServer(makeMockWhoopClient()).server,
+    });
+    cleanup = async (): Promise<void> => {
+      await httpResult.close();
+    };
+    const addr = httpResult.server.address();
+    if (!addr || typeof addr === "string") throw new Error("no port");
+    const mcpUrl = `http://127.0.0.1:${addr.port}/mcp`;
+
+    const post = (method: string, id: number, params?: unknown): Promise<Response> =>
+      fetch(mcpUrl, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${authToken}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method, id, ...(params ? { params } : {}) }),
+      });
+
+    const initParams = {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "t", version: "0" },
+    };
+
+    // Two independent initialize requests with NO session id reuse — both must
+    // succeed (the old shared stateful transport 400s on the second).
+    const init1 = await post("initialize", 1, initParams);
+    expect(init1.status).toBe(200);
+    const init2 = await post("initialize", 2, initParams);
+    expect(init2.status).toBe(200);
+
+    // A tool listing on a fresh stateless request returns the tool set.
+    const list = await post("tools/list", 3, {});
+    expect(list.status).toBe(200);
+    const text = await list.text();
+    expect(text).toContain("get_profile");
+  }, 15_000);
+
   it("accepts a connector-issued JWT at /mcp and rejects a forged one", async () => {
     // Reproduces the claude.ai web/mobile path: the connector signs a JWT
     // access token that /mcp must accept alongside the static admin bearer.

--- a/tests/transport/http-mcp-integration.test.ts
+++ b/tests/transport/http-mcp-integration.test.ts
@@ -114,4 +114,93 @@ describe("HTTP transport — MCP integration", () => {
     const body = (await r.json()) as { issuer: string };
     expect(body.issuer).toMatch(/^https:\/\/example\.com\/?$/);
   });
+
+  it("accepts a connector-issued JWT at /mcp and rejects a forged one", async () => {
+    // Reproduces the claude.ai web/mobile path: the connector signs a JWT
+    // access token that /mcp must accept alongside the static admin bearer.
+    const { OAuthConnectorProvider } = await import("../../src/transport/oauth-connector.js");
+    const { deriveJwtSecret } = await import("../../src/transport/oauth-helpers.js");
+    const { signToken, ACCESS_TOKEN_TTL_SECONDS } = await import(
+      "../../src/transport/oauth-jwt.js"
+    );
+    const { safeTokenCompare } = await import("../../src/transport/http.js");
+
+    const jwtSecret = await deriveJwtSecret("a".repeat(40));
+    const provider = new OAuthConnectorProvider({
+      client: {
+        clientId: "whoop-mcp-connector",
+        redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+      },
+      allowedRedirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+      jwtSecret,
+      scopes: ["mcp"],
+    });
+
+    const jwt = await signToken(
+      {
+        clientId: "whoop-mcp-connector",
+        scopes: ["mcp"],
+        ttlSeconds: ACCESS_TOKEN_TTL_SECONDS,
+        type: "access",
+      },
+      jwtSecret
+    );
+
+    const authToken = "static-admin-token-0123456789abcdef";
+    const verifyBearer = async (token: string): Promise<boolean> => {
+      if (safeTokenCompare(token, authToken)) return true;
+      try {
+        await provider.verifyAccessToken(token);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const { server: mcpServer } = createWhoopServer(makeMockWhoopClient());
+    const httpResult = await createHttpServer({ authToken, port: 0, verifyBearer });
+    await mcpServer.connect(httpResult.transport);
+    cleanup = async (): Promise<void> => {
+      provider.stop();
+      await httpResult.close();
+    };
+
+    const addr = httpResult.server.address();
+    if (!addr || typeof addr === "string") throw new Error("no port");
+    const mcpUrl = `http://127.0.0.1:${addr.port}/mcp`;
+    const initBody = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "initialize",
+      id: 1,
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "t", version: "0" },
+      },
+    });
+
+    // Valid connector JWT clears the auth gate (may be a non-401 transport code).
+    const good = await fetch(mcpUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${jwt}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: initBody,
+    });
+    expect(good.status).not.toBe(401);
+
+    // A forged token is rejected at the gate.
+    const bad = await fetch(mcpUrl, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer forged.jwt.token",
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: initBody,
+    });
+    expect(bad.status).toBe(401);
+  });
 });

--- a/tests/transport/http.test.ts
+++ b/tests/transport/http.test.ts
@@ -211,6 +211,56 @@ describe("HTTP Server", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Custom verifyBearer (OAuth connector JWT path) — /mcp must accept tokens
+  // the injected verifier approves, not only the static admin bearer.
+  // ---------------------------------------------------------------------------
+
+  describe("/mcp with custom verifyBearer (async JWT-style verifier)", () => {
+    beforeEach(async () => {
+      const result = await createHttpServer({
+        ...defaultOptions,
+        // Simulates index.ts wiring: accept the static bearer OR a "JWT".
+        verifyBearer: (token: string): Promise<boolean> =>
+          Promise.resolve(token === "test-token-abc123" || token === "connector-jwt-xyz"),
+      });
+      server = result.server;
+      cleanup = result.close;
+    });
+
+    it("accepts a connector-issued token approved by verifyBearer", async () => {
+      const res = await request(server, "/mcp", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer connector-jwt-xyz",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+      });
+      expect(res.status).not.toBe(401);
+    });
+
+    it("still accepts the static admin bearer", async () => {
+      const res = await request(server, "/mcp", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token-abc123",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+      });
+      expect(res.status).not.toBe(401);
+    });
+
+    it("returns 401 for a token the verifier rejects", async () => {
+      const res = await request(server, "/mcp", {
+        method: "POST",
+        headers: { authorization: "Bearer forged-token" },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Connection limiting
   // ---------------------------------------------------------------------------
 

--- a/tests/transport/oauth-connector.test.ts
+++ b/tests/transport/oauth-connector.test.ts
@@ -536,6 +536,28 @@ describe("createOAuthApp (integration)", () => {
     }
   });
 
+  it("password page CSP allows form-action to the redirect_uri origin", async () => {
+    // Regression: form-action 'self' alone blocks the post-authorize 302 back
+    // to the client (e.g. https://claude.ai), killing the OAuth flow in-browser.
+    const ctx = await startApp();
+    try {
+      const url = new URL(`${ctx.baseUrl}/authorize`);
+      url.searchParams.set("client_id", ctx.clientId);
+      url.searchParams.set("redirect_uri", ctx.redirectUri);
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("code_challenge", "abc");
+      url.searchParams.set("code_challenge_method", "S256");
+      url.searchParams.set("state", "xyz-state");
+
+      const res = await fetch(url, { redirect: "manual" });
+      const csp = res.headers.get("content-security-policy") ?? "";
+      const redirectOrigin = new URL(ctx.redirectUri).origin;
+      expect(csp).toContain("form-action 'self' " + redirectOrigin);
+    } finally {
+      await ctx.close();
+    }
+  });
+
   it("POST /authorize with wrong password re-renders form with 401", async () => {
     const ctx = await startApp();
     try {


### PR DESCRIPTION
## Why
A bare `git pull` on the VM does **not** deploy. The service runs the compiled `dist/` under a long-lived process, so pulling without `npm run build` + `systemctl restart` leaves the old code running. This is exactly what happened with the token-refresh fix (PR #1) — it was pulled but never built/restarted, so the VM ran the buggy pre-fix build for ~12 days.

## What
- `docs/deploy/update.sh` — idempotent one-step deploy: `git pull` → `npm ci` → `npm run build` → `npm prune --omit=dev` → `chown` → `systemctl restart` → authed `/health` check. Fails loudly if the service isn't active or the WHOOP upstream isn't reachable after restart, with a pointer to token re-seeding.
- Runbook "Update the server" now points to the script instead of the manual chain.

## Verified
`bash -n` clean; the underlying steps were just run by hand on the live VM to recover it (build now contains the fix, `/health` reports `whoopApi: "ok"`, real WHOOP call returns 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)