### PR TITLE
feat: add trustworthy personal analytics and aggregate privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Target: **0.7.0 — Trustworthy Personal Analytics**. Not yet published; package
+metadata remains 0.6.1 until the manual client and release-review gates pass.
+
+### Added
+- `get_baselines`: personal percentile bands with baseline self-exclusion, calibration filtering, minimum sample counts and explicit truncation.
+- `get_sleep_debt`: observed nightly deficits, separate WHOOP standing debt, circular local-clock consistency and bounded nightly output.
+- Output schemas and equivalent structured/JSON-text results for all 16 tools.
+- Process-level aggregate privacy mode with a five-tool allowlist, explicit projections and no raw resources or incompatible prompts.
+- Local-only `doctor` command with JSON output and stable exit codes.
+- Site release preview covering personal analytics, current-day safeguards,
+  aggregate privacy and diagnostics, with published-install instructions clearly separated.
+
+### Fixed
+- `get_today` now matches recovery to the current cycle and primary sleep, checks score states, skips naps, and does not substitute older data for pending or invalid current sleep.
+- Accept nullable provider score objects and open-cycle end timestamps.
+- Tool/resource errors no longer expose provider bodies or arbitrary internal messages.
+- Targeted compatible dependency refresh clears runtime and high/critical audit findings. Three moderate development-only Vitest findings remain; a major test-runner migration is deferred.
+
+### Compatibility
+- `get_today.sleep.total_hours` retains time-in-bed semantics; new `time_in_bed_hours` and `asleep_hours` are explicit. Summaries use asleep time; missing optional sleep percentages now return null instead of zero.
+- New current-day/analytics metadata labels data quality and recorded-offset day attribution. Calendar/weekly-summary UTC grouping remains unchanged.
+- Aggregate mode intentionally reduces capabilities and output detail. Standard remains the default. No new runtime dependency, OAuth scope, WHOOP endpoint or health-data storage was added.
+
+### Verification
+- 750 → **797 tests** across 43 files, including real stdio subprocess and authenticated HTTP tests with synthetic WHOOP data.
+- Line coverage: **95.61% overall**, **98.84% API**, **99.18% auth**. Lint, typecheck, build and source/test formatting pass.
+- Runtime dependency audit: zero findings. Three moderate development-only Vitest entries remain; no major-version migration or risk suppression was applied.
+- Manual desktop-client smoke testing and publication remain separate release gates; automated transport tests do not replace client UI verification.
+
 ## [0.6.1] - 2026-08-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-08
+
+### Fixed
+- **Token refresh path recovered for non-JSON 401 responses** (#219) — `parseErrorBody()` now reads the response body once and parses JSON from the captured text, preventing undici's `Body is unusable: Body has already been read` failure that previously blocked 401 refresh handling.
+- **Refreshed access token now persists across subsequent client calls** (#219) — after a successful 401 refresh, the client stores the new token for future requests to avoid repeated `401 -> refresh -> retry` cycles.
+
+### Test count
+- 748 → **750** (+2 regression tests for #219). Full suite, lint, typecheck, and build pass.
+
 ## [0.6.0] - 2026-06-13
 
 ### Added
@@ -152,7 +161,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI entry point** — `npx whoop-mcp` with environment variable configuration
 - **202 tests** with full coverage of auth, API client, tools, and error handling
 
-[Unreleased]: https://github.com/shashankswe2020-ux/whoop-mcp/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/shashankswe2020-ux/whoop-mcp/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/shashankswe2020-ux/whoop-mcp/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/shashankswe2020-ux/whoop-mcp/compare/v0.5.2...v0.6.0
 [0.2.0]: https://github.com/shashankswe2020-ux/whoop-mcp/compare/v0.1.1...v0.2.0
 [0.1.2]: https://github.com/shashankswe2020-ux/whoop-mcp/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/shashankswe2020-ux/whoop-mcp/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that 
 
 ## Features
 
-- 🏋️ **14 health data tools** — recovery, sleep, workouts, cycles, body measurements, profile, weekly summaries, trend analysis, period comparisons, individual record lookups, today's snapshot, and calendar grid
+> **Upcoming 0.7.0:** This branch includes the features below. The published npm
+> package remains **0.6.1** until the [release checklist](docs/plans/task-17-v070-trustworthy-personal-analytics.md)
+> is completed. Existing npm/npx quickstarts install the published release, not this preview.
+
+- 🏋️ **16 health data tools** — recovery, sleep, workouts, cycles, body measurements, profile, summaries, trends, comparisons, record lookups, today's snapshot, calendar, personal baselines, and sleep debt
 - 📊 **4 MCP Resources** — ambient health context (latest recovery, sleep, cycle, profile) available without explicit tool calls
 - 💬 **5 MCP Prompts** — guided conversation starters for common health queries
 - 📅 **Rich natural date expressions** — use "last 7 days", "this week", "last 2 weeks", "last 3 months", "this quarter", "last year", "2026-05", and more
 - 📈 **Built-in analytics** — weekly summaries, trend detection (linear regression), and period comparisons computed server-side
+- **Personal analytics (0.7.0)** — personal baseline distributions and sleep deficits with sample counts, missing-data safeguards and bounded output
+- **Structured results (0.7.0)** — output schemas and matching JSON-text results for all tools
+- **Aggregate privacy (0.7.0)** — five allowlisted tools, no raw resources/prompts, and no caller override of the process policy
+- **Local diagnostics (0.7.0)** — `doctor` checks configuration and token-file metadata without network or OAuth activity
 - 🔐 **Secure OAuth2** — browser-based authentication with automatic token refresh
 - 🔄 **Resilient** — automatic retry on rate limits, token refresh on expiry, auto-pagination, clear error messages
 - 💾 **Secure token storage** — tokens stored at `~/.whoop-mcp/tokens.json` with `0600` permissions
@@ -55,7 +63,7 @@ this is an ecosystem comparison, not a source-code security audit._
   This project provides the first two and supports both local stdio and
   authenticated Streamable HTTP; it does not claim to be a security audit.
 
-**Why this package stands out**
+**Published 0.6.1 strengths**
 
 - 14 domain and analytical tools, 4 ambient resources, and 5 prompts in one
   standalone package.
@@ -63,6 +71,10 @@ this is an ecosystem comparison, not a source-code security audit._
   and Zod are required.
 - Published to npm and the official MCP Registry, with documented OAuth,
   token refresh, retries, caching, HTTP hardening, and Inspector verification.
+
+The table above describes published artifacts, so its 14-tool count is intentional.
+The upcoming 0.7.0 adds two tools; its scope and evidence are in the
+[September feature scan](docs/ideas/sota-feature-scan-2026-09-10.md).
 
 **Evidence and reproducibility:** package names, versions, publish dates,
 dependency counts, descriptions, and `mcpName` values come from the npm Registry
@@ -458,7 +470,46 @@ Get today's complete health snapshot — recovery score, last night's sleep, cur
 
 **Returns:** Recovery score with zone, sleep breakdown (hours, stages, performance), current strain, last workout (sport + strain), and a human-readable summary.
 
+Recovery is returned only when it matches the current local cycle and primary sleep.
+Pending or invalid primary sleep never falls back to an older recovery. Missing optional
+sleep percentages are `null`, not zero. `data_quality` distinguishes missing, pending,
+stale, unscored, calibrating, invalid and failed sources; cache status and fetch time
+remain unknown when the client cannot establish them.
+
+For compatibility, `sleep.total_hours` remains time in bed. Use `time_in_bed_hours`
+or `asleep_hours` explicitly; summaries now use scored asleep stages. The latest
+workout includes `occurred_at` and recording percentage and may be historical.
+
 ---
+
+### `get_baselines`
+
+Returns personal distributions for HRV, resting heart rate, respiratory rate,
+asleep hours and recovery score. `baseline_days` is an integer from 14 to 180
+(default 30). Each band includes mean, median, standard deviation, percentiles,
+sample size and the latest observation's midrank percentile.
+
+The latest observation and current local day are excluded from each baseline.
+Calibrating, unscored, invalid and unjoinable observations are excluded. A metric
+needs 14 historical points after exclusions; otherwise its band is null with an
+insufficient-data status. Constant distributions are labeled explicitly.
+
+### `get_sleep_debt`
+
+Analyzes scored main sleeps using `days` (3-90, default 14) and optional `start`
+(ISO or a supported relative expression). With `start`, the window extends forward
+for `days` calendar days, clamped to evaluation time. Resolved bounds are returned.
+
+`total_debt_hours` sums observed nightly deficits. Need excludes WHOOP's accumulated
+debt component and preserves the signed nap adjustment; achieved sleep is light +
+slow-wave + REM. `standing_debt_hours` is the latest WHOOP debt value, separately
+dated, not the deficit sum. Missing nights are not zero-sleep nights; fewer than
+three usable nights returns null aggregates. Circular local-clock statistics describe
+consistency and heuristic social jetlag, not clinical diagnoses or recovery forecasts.
+
+Analytics paginate up to 500 records per source and report upstream truncation.
+Sleep-debt calculations use all selected records but echo at most 30 nights, with
+a separate `output_capped` flag. Both tools include a statistical/medical disclaimer.
 
 ### `get_calendar`
 
@@ -472,6 +523,52 @@ Get a day-by-day grid of recovery, sleep, and strain for a date range. Perfect f
 | `start` | string | No | Start date — ISO 8601 or relative expression ("last 14 days", "this month"). Defaults to N days ago. |
 
 **Returns:** Per-day grid with recovery score + zone (green/yellow/red), sleep hours, sleep performance, and strain. Includes period averages.
+
+---
+
+## Structured Results And Privacy
+
+All tools advertise `outputSchema` and return validated `structuredContent` alongside
+equivalent JSON text for older clients. Provider bodies and internal error details
+are not returned in tool or resource errors.
+
+Set `WHOOP_MCP_PRIVACY_MODE=aggregate` in the server process environment to expose
+only `get_weekly_summary`, `compare_periods`, `get_trend`, `get_baselines`, and
+`get_sleep_debt`. Per-record arrays, latest observations, standing debt, identity
+fields and exact activity timestamps are omitted. Period bounds are date-only.
+Raw resources and all five existing prompts are unavailable in this mode because
+their workflows require raw tools/resources. Tool arguments cannot override the policy.
+
+The default is `standard`, retaining all 16 tools, four resources and five prompts.
+The standard-mode resource and prompt lists later in this README do not apply to
+aggregate mode. To enable aggregation in a client configuration, add
+`"WHOOP_MCP_PRIVACY_MODE": "aggregate"` to the server's existing `env` object.
+Restart and reconnect after changing the process policy. Aggregate mode minimizes
+disclosure; it is not anonymization, does not erase previously shared data, and
+still sends health aggregates to the assistant provider.
+
+`get_today` and the two new analytics tools use recorded offsets for local-day
+attribution. Existing calendar and weekly-summary grouping remains UTC for compatibility.
+An offset is not a timezone database and cannot reconstruct within-sleep DST changes.
+
+## Local Diagnostics
+
+For a local build of this unreleased branch:
+
+```sh
+npm ci --ignore-scripts
+npm run build
+node dist/index.js doctor --json
+```
+
+After 0.7.0 is published and installed, use `whoop-ai-mcp doctor` or
+`whoop-ai-mcp doctor --json` directly. The command is not present in published 0.6.1.
+
+Checks runtime, configuration presence, privacy/transport settings and token-file
+metadata without reading token contents, calling WHOOP, launching OAuth or writing
+files. Exit codes: 0 = locally ready, 1 = remediation needed, 2 = invalid arguments.
+Token validity and granted scopes remain unknown; `setup --verify` is the explicit
+live check. POSIX private permissions are checked; Windows ACL privacy is not verified.
 
 ---
 

--- a/docs/ideas/sota-feature-scan-2026-09-10.md
+++ b/docs/ideas/sota-feature-scan-2026-09-10.md
@@ -1,0 +1,213 @@
+# WHOOP MCP Feature Opportunity Scan
+
+Date: 2026-09-10. Status: research recommendations, not an approved implementation plan.
+
+## Recommendation
+
+Prioritize trustworthy, composable answers over tool count: structured results,
+explicit data quality, privacy controls, then the existing personal-baseline
+analytics roadmap. Add proactive updates only after approving the hosting and
+security requirements. Do not promise proprietary WHOOP metrics that the public
+member API does not expose.
+
+## Verified Local Baseline
+
+- Rebased local `main` onto `origin/main` at `1a370ae`; two local commits remain ahead.
+- Package version is `0.6.1`; 14 tools, four resources, five prompts, HTTP and stdio.
+- The rebased source passes 750 tests across 37 test files with the installed dependencies.
+- [Server result formatting](../../src/server.ts) serializes JSON into text blocks;
+  it does not yet supply `structuredContent` or `outputSchema`. Read-only annotations
+  already exist, so annotations are not a new feature opportunity.
+- [Task 16](../plans/task-16-v4-personal-analytics.md) and the
+  [coaching draft](../specs/v5-coaching-personalization.md) are plans, not shipped tools.
+  Their `0.6.0` target and older baseline counts are stale relative to the package.
+  Choose a future release label when approving them; this scan does not relabel drafts.
+- The [README comparison](../../README.md) contains an August 30 registry snapshot.
+  Competitor feature statements are documentation signals, not proof of quality or security.
+
+## Live Ecosystem Evidence
+
+Public npm metadata was queried on September 10 for four representative packages.
+This is a targeted comparison, not an exhaustive market survey. Dependency counts
+are direct runtime dependencies, not total transitive packages. `mcpName` in a
+manifest is an identity declaration, not independent registry-listing verification.
+
+| Package                | Latest | Published UTC | Runtime deps | Evidence-backed signal                                                                                                         |
+| ---------------------- | ------ | ------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `whoop-ai-mcp`         | 0.6.1  | 2026-08-07    | 2            | Existing analytics, HTTP/stdin-stdout transports, no database.                                                                 |
+| `whoop-mcp-unofficial` | 0.6.5  | 2026-08-29    | 6            | Documents privacy modes, optional SQLite, synthetic demo, diagnostics and a CLI tool-call interface.                           |
+| `mcp-server-whoop`     | 0.2.2  | 2026-07-17    | 2            | Documents five focused tools, pending-score safeguards, local timestamps, identity suppression and artifact security evidence. |
+| `@nchemb/whoop-mcp`    | 0.2.0  | 2026-04-27    | 4            | Documents local SQLite history, read-only SQL and an OAuth relay with a stated test-user capacity limit.                       |
+
+Metadata sources: [this package](https://registry.npmjs.org/whoop-ai-mcp),
+[unofficial](https://registry.npmjs.org/whoop-mcp-unofficial),
+[mcp-server-whoop](https://registry.npmjs.org/mcp-server-whoop),
+[@nchemb](https://registry.npmjs.org/@nchemb%2Fwhoop-mcp).
+Feature sources: [davidmosiah](https://github.com/davidmosiah/whoop-mcp),
+[Yadheedhya06](https://github.com/Yadheedhya06/mcp-server-whoop),
+[nchemb](https://github.com/nchemb/whoop-mcp).
+
+The repository documentation was read, but competitor packages were not installed,
+executed or security-audited. Main-branch documentation may differ from published
+artifacts. Privacy-mode labels do not establish aggregate-only guarantees. Claims
+that data "never leaves the machine" must account for the assistant receiving it.
+
+The useful competitive distinction is not maximum tool count: one alternative
+emphasizes broad automation, another a deliberately narrow and explicit data
+contract. This project can retain its two-dependency/no-database default while
+adopting better output semantics and diagnostics.
+
+## Already Planned, Not New Discoveries
+
+Task 16 already covers personal baselines, anomalies, sleep debt, training load,
+weekday patterns, workout analytics, event readiness, travel impact, reports and
+lagged correlations. Its deferred tier includes behavior logging and CSV import.
+The coaching draft adds daily recommendations, sleep projections and population
+benchmarks. These remain useful backlog items, but should not be counted again as
+new features discovered by this scan.
+
+## Prioritized Opportunities
+
+Effort is relative: S = a bounded existing surface; M = shared behavior or a new
+analytical slice; L = persisted state, hosting or cross-client integration.
+Priorities are engineering judgment, not measured customer demand.
+
+| Priority | Opportunity                              | User value and smallest useful increment                                                                                                                                                                           | Effort and dependencies                                                                                   |
+| -------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| P0       | Structured results and evidence metadata | Add `outputSchema` and `structuredContent`, retaining JSON text compatibility. Include units, requested/observed windows, source IDs, computation version and exclusions where applicable. Start with `get_today`. | M; existing SDK and Zod, no new WHOOP endpoint.                                                           |
+| P0       | Data-quality and freshness explanations  | Answer "Is this really today's recovery?" Distinguish pending scores, missing data, calibration, incomplete recording and truncated history. Expose fetch time separately from source update time.                 | M; build shared conventions alongside task 16b.                                                           |
+| P0       | Minimal-disclosure mode                  | Opt-in aggregate-only responses and identity suppression across tools, resources and reports. State clearly that data sent to an assistant is outside this server's privacy boundary.                              | M; common output policy and cross-surface tests; no new storage needed.                                   |
+| P1       | Reliable cross-tool local-day context    | Make today, calendar, summaries and analytics agree around midnight. Join records by IDs first, label local-day attribution explicitly and never substitute an old recovery for a missing current one.             | M; extend task 16b to existing tools through an approved migration.                                       |
+| P1       | Explain a recovery change                | Show concurrent changes in sleep, load, HRV and RHR relative to the user's prior baseline, with coverage and uncertainty. Describe associations, not causal contributions to WHOOP's proprietary score.            | M; composition over task 16 foundations, not a duplicate correlation engine.                              |
+| P1       | Nap and workout-timing analysis          | Compare next main-sleep outcomes after naps or earlier/later workouts, with matched-day counts and baseline context.                                                                                               | M; extend planned workout/sleep analytics, explicit confounding caveat.                                   |
+| P1       | Training-zone distribution               | Summarize WHOOP heart-rate-zone minutes by week and sport; expose recording coverage. Do not label WHOOP zones as laboratory lactate thresholds or infer VO2 max.                                                  | S-M; workout score fields, can fit inside planned workout analytics.                                      |
+| P1       | Shareable bounded report resources       | Extend planned report generation with an MCP resource link for larger outputs, explicit expiry and redaction; retain a compact inline summary.                                                                     | M; resource authorization and memory/size limits. Disk persistence requires separate approval.            |
+| P2       | Live refresh from verified webhooks      | Invalidate stale records and notify connected resource subscribers when recovery/sleep/workout changes. Add reconciliation for missed events.                                                                      | L; HTTPS receiver, replay/dedup protection, account binding and deployment approval.                      |
+| P2       | Guided personal experiments              | Extend deferred behavior logging with a chosen intervention, baseline period, adherence tracking and before/after effect estimates. Observational results must not imply causality.                                | L; consent, secure local persistence, deletion/export and statistical review.                             |
+| P2       | Long-running report jobs                 | Progress, cancellation and optional task execution for bounded historical reports, only if measured latency warrants it.                                                                                           | M-L; MCP task support is experimental in the cited spec; require client negotiation and result isolation. |
+
+## Public API Feasibility
+
+The [WHOOP API reference](https://developer.whoop.com/api) is the authority for
+data availability, not screenshots of the consumer app.
+
+- Existing member scopes expose recovery HRV/RHR/SpO2/skin temperature, sleep
+  stages/need/consistency/efficiency, cycle strain/energy, and workout zones,
+  recording percentage, distance and elevation. These support the P0/P1 ideas.
+- The reviewed member API does not expose journal entries, raw continuous heart
+  rate, ECG, blood pressure, Healthspan/WHOOP Age or strength sets/reps. Treat these
+  as unavailable through existing scopes, not as tools waiting for implementation.
+- The current reference also documents **trusted-partner lab operations** under a
+  separate client-credentials authorization scheme. Their presence is not evidence
+  that an ordinary member OAuth app can retrieve lab results. Defer pending partner access.
+- Do not claim the entire API is read-only: member access revocation is documented
+  as `DELETE /v2/user/access`. A disconnect/revoke feature is feasible but needs
+  explicit approval for the new endpoint and token lifecycle changes.
+- [Webhooks](https://developer.whoop.com/docs/developing/webhooks/) are configured
+  in the developer dashboard, not through an assumed webhook-management REST API.
+  A receiver is feasible even though the old `manage_webhooks` proposal was deferred.
+- V2 recovery events identify the associated **sleep UUID**, not the cycle ID.
+  Verify timestamp-plus-raw-body HMAC-SHA256 signatures, deduplicate deliveries,
+  handle deletions, bind the user ID, and reconcile missed events. WHOOP does not
+  currently document cycle/day-strain/body-measurement webhook events.
+- Resource notifications need a connected, supporting MCP client. Offline alerts
+  require a scheduler and delivery channel; neither a webhook nor MCP alone supplies them.
+
+## Statistical And Product Gates
+
+1. Ship missingness, calibration and baseline self-exclusion before interpreting scores.
+   Constant baselines should carry an explicit limitation, not reassurance based only on `z=0`.
+2. Review task 16's ACWR and coaching thresholds before implementation. Do not turn a
+   heuristic ratio into a validated injury-risk category or a guaranteed training prescription.
+3. For lag searches and repeated correlations, address autocorrelation, multiple
+   comparisons, minimum paired observations and uncertainty. A naive Pearson cutoff
+   alone is not sufficient evidence for a personalized causal recommendation.
+4. Offset changes indicate clock changes, not confirmed travel; an offset is not an
+   IANA timezone and cannot determine future DST. Ask for timezone context when forecasting.
+5. Distinguish sleep opportunity planning from predicting recovery color or race performance.
+   Population comparisons need measurement-compatible sources, not invented percentile tables.
+6. Start with explicit evidence fields; evaluate assistant answer accuracy and tool
+   selection on fixed scenarios before claiming these features improve coaching.
+
+## Suggested Delivery Order
+
+1. Approve a future release label and reconcile the stale task-16/coaching baselines.
+2. Ship one `get_today` structured-output/data-quality slice with compatibility tests.
+3. Add privacy policy enforcement across every output surface.
+4. Build task 16a/16b and the baseline/sleep slices, then add recovery-change and timing views.
+5. Extend reports with bounded resources. Consider webhooks or persistent experiments
+   only after explicitly approving their additional storage, hosting and security scope.
+
+## Additional Confirmed Opportunities
+
+### P1: Diagnostics And Synthetic Demo (S-M)
+
+Add a non-interactive `doctor` command and an explicitly synthetic demo mode.
+Report configuration readiness, granted scopes when known, token-expiry status
+and available data domains without exposing credentials or health records.
+Local-only checks should make no WHOOP calls; live verification must be explicit.
+Use the same output schemas for synthetic and real results, with an unmistakable
+demo marker. Existing `setup --verify` is useful but is not the whole diagnostics
+experience. Competitor evidence: `whoop_connection_status`, `whoop_data_inventory`,
+`whoop_demo`, and `doctor` in the unofficial server.
+
+### P1: CLI Access To Existing Tools (M)
+
+Expose the same validated read-only handlers to scripts and agents that do not
+support MCP, with JSON output, stable exit behavior and no duplicated analytics.
+An allowlisted `call` command could enable scheduled personal reports without
+running a remote server. Do not accept arbitrary endpoints, shell fragments or
+credentials in arguments. Competitor evidence: the unofficial server's CLI/skill
+interface. A distributable usage skill is optional, not a reason to fork handlers.
+
+### P1: Interactive In-Chat Analytics (M-L, Gated)
+
+[MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) now documents
+interactive HTML resources rendered within supporting hosts, including Claude
+and VS Code. A recovery calendar with click-through records, baseline bands and
+date/metric filters would make the existing data easier to inspect.
+
+Start with a read-only visualization of `get_calendar` or `get_trend`, reuse the
+structured contract, and retain text/JSON results for unsupported clients. Keep
+credentials server-side, use restrictive CSP and avoid third-party analytics.
+The extension uses a `ui://` resource and `_meta.ui.resourceUri`; it is not an
+ordinary resource link that every client will render. Any additional runtime
+package or frontend build tooling requires approval before implementation.
+
+### P2: Offline History And Bounded Exploration (L, Gated)
+
+An opt-in local archive would enable long-window queries and reports without
+repeated full-history downloads. Both SQLite-based alternatives show this use
+case, but adding a database would change this project's default architecture.
+Prefer bounded typed filters/aggregations over unrestricted SQL initially.
+
+Require storage consent, retention/deletion/export controls, account separation,
+resumable sync, correction/deletion handling and visible last-sync timestamps.
+[WHOOP documents](https://developer.whoop.com/docs/developing/rate-limiting/)
+default limits of 100 requests/minute and 10,000/day, with headers describing the
+actual budget. Budget pagination and deduplicate shared fetches before attempting
+year-scale history; never silently exceed the existing record caps.
+
+## Verification And Release Caution
+
+- `npm ci --ignore-scripts` synchronized installed dependencies to the rebased lockfile.
+- After synchronization: 750 tests passed; lint, typecheck and build passed.
+- Rebase `range-diff` showed both local patches unchanged. All six restored draft
+  files matched the saved stash, including hashes for the three untracked files.
+- npm reported 15 dependency advisories: two low, four moderate, seven high and
+  two critical. These are registry audit findings, not verified exploitability in
+  this server. Triage runtime versus development exposure before the next release;
+  no automatic dependency fixes were applied as part of this feature scan.
+- No features, public endpoints, OAuth changes, storage changes, commits or pushes
+  were added by this scan. The named pre-rebase stash remains as a backup.
+
+## Protocol Sources
+
+- [MCP tools, structured content, output schemas and resource links](https://modelcontextprotocol.io/specification/2025-11-25/server/tools).
+- [MCP resource subscriptions](https://modelcontextprotocol.io/specification/2025-11-25/server/resources).
+- [MCP Apps and host support](https://modelcontextprotocol.io/docs/extensions/apps).
+- [MCP tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks):
+  experimental in this version, capability-negotiated, with cancellation, TTL and isolation requirements.
+
+These are version-pinned protocol sources, not a claim that every installed client
+supports every feature. Verify target SDK/client combinations before implementation.

--- a/docs/plans/task-16-v4-personal-analytics.md
+++ b/docs/plans/task-16-v4-personal-analytics.md
@@ -1,0 +1,501 @@
+# Task 16: V4 Personal Baseline Analytics
+
+> **Next-release implementation (2026-09-10):** The user approved core reliability plus
+> personal baselines and sleep debt. See the [0.7.0 release spec](../specs/v070-trustworthy-personal-analytics.md)
+> and [execution checklist](task-17-v070-trustworthy-personal-analytics.md).
+> The required subset of 16a/16b, plus 16d and 16e under the new contract, is implemented
+> in the working tree. Remaining tasks stay in the backlog; the historical checklists
+> below are not a claim that the entire foundation or ten-tool release is complete.
+> The historical target/baseline below is not the current release commitment.
+> Package metadata remains 0.6.1 until release verification. Standard mode now has
+> 16 tools, four resources and five prompts; aggregate mode exposes five tools only.
+
+> **Spec:** [`docs/specs/v4-personal-analytics.md`](../specs/v4-personal-analytics.md)
+> **Historical target:** `0.6.0` (superseded as a next-release label). The backlog's `correlate_metrics` supersedes the never-built `get_correlations` from [task-14](task-14-v060-analytics-moat.md).
+> **Historical baseline:** v0.5.2 — 14 tools, 4 resources, 5 prompts, 716 tests, lint/typecheck/build clean
+> **Depends on (ready):** existing shipped utilities only — no dependency on task-14/15. Can start immediately.
+> **Depends on:** existing `stats-utils.ts`, `api/types.ts`, `api/pagination.ts` (`fetchAllPages`), `date-utils.ts`, `get-calendar.ts`
+> **Created:** 2026-06-11
+
+---
+
+## Overview
+
+Add a personal-baseline analytics layer to the WHOOP MCP server: 10 new tools that interpret a
+user's data against their own rolling baseline (illness early-warning, personal normals, sleep
+debt, training load, weekday patterns, workout analytics, event readiness, travel impact, report
+export, and arbitrary-pair lagged correlation). All computation is in-process pure TypeScript on
+the existing read-only OAuth scopes — no new runtime dependencies, no new scopes, no external DB.
+
+This plan covers **Tier 1 + Tier 2 + Tier 3** of the spec. **Tier 4** (`log_behavior` + CSV
+import) is intentionally **out of scope here** — it introduces new persisted state and an
+untrusted-input surface and is deferred to a separate gated plan pending a dedicated security
+audit (spec D-5).
+
+## Architecture Decisions
+
+1. **Foundation-first, then vertical slices.** Shared math (`stats-utils.ts` extensions) and shared
+   analytics conventions land first because every tool depends on them. After that, each tool is a
+   self-contained vertical slice: handler + Zod schema (co-located) + tests + `server.ts`
+   registration. This keeps each task to ~3 files and leaves the system green after every task.
+
+2. **Shared conventions live in one module, not copy-pasted.** A new `src/tools/analytics-utils.ts`
+   centralizes the cross-cutting rules the spec mandates: the canonical `DISCLAIMER` string, the
+   SCORED-only + self-exclusion baseline filter, the cross-source wake-day key (reusing the
+   `get-calendar` local-day logic), the `data_points` cap (security M-2), and the
+   pagination-with-`truncated`-flag helper (`ABSOLUTE_MAX_RECORDS = 500`). Single source of truth =
+   one place to test, no drift between tools.
+
+3. **CSV writing (incl. formula-injection neutralizer) lives with its only current consumer,
+   `generate_report`,** but is written as a standalone, exported, reuse-ready helper so the deferred
+   Tier-4 import re-exports through the same code path (spec C-1). It is *not* hoisted into the
+   foundation module because no other Tier 1–3 tool needs it.
+
+4. **`correlate_metrics` supersedes the never-built `get_correlations`.** `get_correlations` was
+   reserved on the roadmap but never implemented (confirmed: no `get-correlations.ts` in `src/tools`),
+   so there is nothing to deprecate or alias — `correlate_metrics` ships clean (resolves D-4 with no
+   migration work).
+
+5. **Tools never modify each other.** Cross-tool reuse happens only through `analytics-utils.ts` and
+   `stats-utils.ts`. No tool imports another tool.
+
+6. **Each tool's acceptance criteria are defined in the spec.** This plan references the spec section
+   per task rather than restating every bullet, and adds the verification command + dependency +
+   file list. The spec is the contract; the plan is the execution order.
+
+7. **The wake-day key is NET-NEW, not a reuse of `get-calendar`.** The shipped `get-calendar` (and
+   `get-today`/`get-weekly-summary`) key days by **UTC** date (`iso.slice(0,10)`), NOT by
+   `timezone_offset` local day. The spec's cross-source convention requires offset-based local-day
+   keying, so 16b builds it from scratch and **documents the divergence** from the existing
+   UTC-keyed tools (a follow-up may migrate those onto the shared key; out of scope here). Because
+   `Recovery` carries no `start`/`timezone_offset` of its own (spec assumption #1), keying a recovery
+   record to a local day requires joining it to its cycle via `cycle_id` — so the 16b helper takes
+   cycle context, and every recovery-consuming tool (16c, 16g, 16l-a) must also fetch cycles.
+
+8. **The `DISCLAIMER` convention is established here.** Confirmed: no existing tool emits a
+   disclaimer, so there is no prior string to match and no competing convention to reconcile — 16b
+   defines the single canonical string for all new interpretive tools.
+
+---
+
+## Dependency Graph
+
+```
+16a stats-utils extensions ──┐
+                             ├──► 16c detect_anomalies ──┐
+16b analytics-utils ─────────┤    16d get_baselines      │
+  (DISCLAIMER, SCORED filter,│    16e get_sleep_debt     ├─► Checkpoint 1 (Tier 1)
+   wake-day key, data_points │    16f get_training_load  │
+   cap, truncated pagination)│    16g get_day_of_week     ┘
+                             │
+                             ├──► 16h get_workout_analytics ─┐
+                             │    16i get_event_readiness    │
+                             │    16j detect_travel_impact   ├─► Checkpoint 2 (Tier 2)
+                             │    16k generate_report        │
+                             │        (+ CSV neutralizer)    ┘
+                             │
+                             └──► 16l-a correlate_metrics core ──┐
+                                  (pair engine + 3 scalar         ├─► Checkpoint 3 (Tier 3)
+                                   presets + .refine)             │
+                                  16l-b derived presets ──────────┘
+                                  (sleep_consistency_vs_hrv,
+                                   workout_strain_vs_recovery_drop)
+                                            │
+                                            ▼
+                                  16m release wiring + cross-tool tests + verification
+```
+
+- **16a and 16b are independent of each other** and can be built in parallel (different files).
+- **16c–16g tool LOGIC/tests are mutually independent**, but every tool task also edits `src/server.ts` (shared imports block + a `registerTool` block). The tool files + test files parallelize cleanly; the `server.ts` edits must be **serialized** (or batched into a single wiring step) to avoid merge churn.
+- **16h–16k** follow the same pattern; `16k` (report) leans on 16b but not on stats.
+- **16l-a/16l-b** depend on 16a (`pearsonR`/`isSignificant`) and 16b (wake-day key). Building them after 16g is a **recommended ordering** (16g exercises the wake-day key first) — not a hard import dependency.
+- **16m** depends on everything.
+
+---
+
+## Task List
+
+### Phase 0 — Foundation
+
+#### Task 16a: `stats-utils.ts` extensions + property tests
+
+**Description:** Add the pure statistical primitives the analytics tools need, alongside the
+existing `mean`/`median`/`standardDeviation`/`linearRegression`/`detectAnomalies`/`trendDirection`.
+
+**Acceptance criteria:**
+- [ ] Exports `percentile(values, p)` — linear interpolation, `p ∈ [0,100]`, p0=min, p100=max, single-element returns that element, empty throws.
+- [ ] Exports `zScore(value, mean, sd)` — returns `0` when `sd === 0` (no NaN).
+- [ ] Exports `rollingWindow(values, size)` — full windows only; `n < size → []`; `size < 1` throws.
+- [ ] Exports `pearsonR(x, y)` — bounded `[-1,1]`; zero-variance → `0`; length-mismatch throws.
+- [ ] Exports `isSignificant(r, n)` via `R_CRITICAL_TABLE` floor-to-nearest-key; `n < 7 → false`.
+- [ ] Exports `correlationStrength(r)` and `correlationDirection(r)`.
+- [ ] Consistent with module behavior: empty array throws; `sd === 0` returns a defined value.
+
+**Verification:** `npm test -- tests/tools/stats-utils.test.ts`
+
+**Dependencies:** None
+
+**Files:** `src/tools/stats-utils.ts` (modify), `tests/tools/stats-utils.test.ts` (modify)
+
+**Estimated scope:** Medium (2 files, many property tests)
+
+---
+
+#### Task 16b: `analytics-utils.ts` shared conventions + tests
+
+**Description:** Create the shared substrate every analytics tool reuses, so the spec's
+cross-cutting rules are implemented and tested exactly once.
+
+**Acceptance criteria:**
+- [ ] Exports canonical `DISCLAIMER = "Statistical observation from your data, not medical advice."` (net-new convention — no existing tool emits a disclaimer; confirmed).
+- [ ] Exports a SCORED-only filter and a baseline self-exclusion helper (excludes "current"/"latest" from the distribution it is compared against).
+- [ ] Exports a cross-source **wake-day key** helper computing the local calendar day from `timezone_offset` (sleep → local `end`/wake day; cycle → local `start` day). **Built from scratch** — the shipped `get-calendar`/`get-today`/`get-weekly-summary` key by UTC `iso.slice(0,10)`, NOT offset-local; the helper's doc comment must state this divergence.
+- [ ] Recovery has no `start`/`timezone_offset`: the helper accepts **cycle context** and keys a recovery record via its cycle (`cycle_id`). Documented so recovery-consuming tools know they must fetch cycles too.
+- [ ] Exports a `capDataPoints` helper enforcing the documented default cap (security M-2); stats are computed on the full set, only the echoed array is capped.
+- [ ] Exports a pagination helper that **imports/wraps** the existing `ABSOLUTE_MAX_RECORDS` and `fetchAllPages` (which already returns `truncated`) from `src/api/pagination.ts` — does NOT redefine them — sizing `maxRecords` to the window and surfacing `truncated` to the tool.
+- [ ] No new runtime dependency; pure TS + existing utils only.
+
+**Verification:** `npm test -- tests/tools/analytics-utils.test.ts`
+
+**Dependencies:** None (independent of 16a)
+
+**Files:** `src/tools/analytics-utils.ts` (new), `tests/tools/analytics-utils.test.ts` (new)
+
+**Estimated scope:** Medium (2 files)
+
+---
+
+### Checkpoint: Foundation (after 16a, 16b)
+- [ ] `npm test -- tests/tools/stats-utils.test.ts tests/tools/analytics-utils.test.ts` green
+- [ ] `npm run typecheck && npm run lint` clean
+- [ ] No NaN escapes any helper; all documented edge cases covered
+
+---
+
+### Phase 1 — Tier 1 Core Tools
+
+> Each Tier 1 task = handler + co-located Zod schema + tests + `server.ts` registration. Acceptance
+> criteria are the spec bullets for that tool (referenced); the checks below are the task-level
+> "definition of done" plus its verification command.
+
+#### Task 16c: `detect_anomalies`
+
+**Description:** Illness/overtraining early-warning — compare today's HRV, RHR, and respiratory rate against the personal rolling baseline; flag |z| beyond threshold (default 2σ).
+
+**Acceptance criteria:** Implements [spec §Tool 1.1](../specs/v4-personal-analytics.md) acceptance bullets, incl. today excluded from its own baseline, direction-aware notes, `sd===0 → z=0/normal`, missing-today → `current:null`, `< 7` points → insufficient-data, disclaimer present. (HRV/RHR come from recovery; respiratory rate from sleep — no wake-day join needed here since each metric uses its own latest SCORED record.)
+
+**Verification:** `npm test -- tests/tools/detect-anomalies.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/detect-anomalies.ts` (new), `tests/tools/detect-anomalies.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+#### Task 16d: `get_baselines`
+
+**Description:** Personal normal ranges — mean/median/sd + p10/p25/p50/p75/p90 per metric, plus `latest` and `latest_percentile`.
+
+**Acceptance criteria:** Implements [spec §Tool 1.2](../specs/v4-personal-analytics.md) bullets, incl. `latest_percentile` ranks `latest` **excluding `latest` itself**, `< 14` points per metric → `null` band, period reflects actual range, disclaimer present.
+
+**Verification:** `npm test -- tests/tools/get-baselines.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/get-baselines.ts` (new), `tests/tools/get-baselines.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+#### Task 16e: `get_sleep_debt`
+
+**Description:** Cumulative sleep debt + bedtime/wake consistency + weekday-vs-weekend social jetlag.
+
+**Acceptance criteria:** Implements [spec §Tool 1.3](../specs/v4-personal-analytics.md) bullets, incl. `needed_hours` = baseline+strain+nap (**excludes** `need_from_sleep_debt_milli`), `need_from_recent_nap_milli` summed as-is (negative preserved — proven by a nap fixture), `achieved` = light+SWS+REM, naps excluded from nightly debt, local-time consistency, `social_jetlag_minutes` null when one group, DST 23h/25h fixtures, `truncated` honored, the echoed `nights[]` array bounded by `capDataPoints` (M-2), disclaimer present.
+
+**Verification:** `npm test -- tests/tools/get-sleep-debt.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/get-sleep-debt.ts` (new), `tests/tools/get-sleep-debt.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files; most fixture-heavy of Tier 1)
+
+---
+
+#### Task 16f: `get_training_load`
+
+**Description:** Coupled ACWR (7d vs 28d), monotony, and sustained high-strain + low-recovery streaks.
+
+**Acceptance criteria:** Implements [spec §Tool 1.4](../specs/v4-personal-analytics.md) bullets, incl. **coupled** ACWR documented in `load_note`, `load_basis` enum (`strain` default / `kilojoule`), insufficient chronic (`<21/28` SCORED or `chronic_load===0`) → `acwr:null` + `acwr_zone:"insufficient_data"` + `provisional:true` (NOT undertraining), `monotony` null when `sd===0`, combined low-recovery-high-strain count, `truncated` honored, disclaimer present.
+
+**Verification:** `npm test -- tests/tools/get-training-load.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/get-training-load.ts` (new), `tests/tools/get-training-load.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+#### Task 16g: `get_day_of_week_patterns`
+
+**Description:** Recovery/sleep/strain broken down by local weekday + weekday-vs-weekend deltas. **This is the first heavy consumer of the wake-day key helper — validates 16b before `correlate_metrics`.**
+
+**Acceptance criteria:** Implements [spec §Tool 1.5](../specs/v4-personal-analytics.md) bullets, incl. local-weekday assignment via `timezone_offset` (recovery keyed through its cycle per 16b — this task fetches cycles + recovery + sleep), no-data days → `null` averages / `sample_size:0`, deltas from non-null aggregates only, highlights name lowest/highest recovery weekday, `<14` days → insufficient, disclaimer present.
+
+**Verification:** `npm test -- tests/tools/get-day-of-week-patterns.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/get-day-of-week-patterns.ts` (new), `tests/tools/get-day-of-week-patterns.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+### Checkpoint 1: Tier 1 Complete (after 16c–16g)
+- [ ] `npm test` green (716 existing + Tier 1 new tests)
+- [ ] `npm run lint && npm run typecheck && npm run build` clean
+- [ ] All 5 Tier 1 tools registered with unique `snake_case` names and valid Zod schemas
+- [ ] Every Tier 1 output carries the canonical disclaimer
+- [ ] Review with human before proceeding to Tier 2
+
+---
+
+### Phase 2 — Tier 2 Nice-to-Have Tools
+
+#### Task 16h: `get_workout_analytics`
+
+**Description:** HR-zone distribution, strain-per-minute efficiency, per-sport rollups, time-of-day buckets.
+
+**Acceptance criteria:** Implements [spec §Tool 2.1](../specs/v4-personal-analytics.md) bullets, incl. zone distribution ~100% (rounding documented), zero-duration guard, case-insensitive `sport` filter, local-time buckets, `<1` SCORED workout → insufficient, disclaimer present.
+
+**Verification:** `npm test -- tests/tools/get-workout-analytics.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/get-workout-analytics.ts` (new), `tests/tools/get-workout-analytics.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+#### Task 16i: `get_event_readiness`
+
+**Description:** Project readiness toward a future event date from the recovery trend; suggest a taper window.
+
+**Acceptance criteria:** Implements [spec §Tool 2.2](../specs/v4-personal-analytics.md) bullets, incl. `event_date` ISO-8601-only + today-or-future (relative expr rejected), correct `days_until_event`, reuse `linearRegression`/`trendDirection`, readiness **clamped [0,100]**, labeled heuristic, `<14` recovery points → insufficient, disclaimer present.
+
+**Verification:** `npm test -- tests/tools/get-event-readiness.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/get-event-readiness.ts` (new), `tests/tools/get-event-readiness.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+#### Task 16j: `detect_travel_impact`
+
+**Description:** Detect timezone shifts from records and quantify recovery rebound days after travel.
+
+**Acceptance criteria:** Implements [spec §Tool 2.3](../specs/v4-personal-analytics.md) bullets, incl. event on consecutive `timezone_offset` change ≥ threshold, `+HH:MM`/`-HH:MM` parsing, rebound = days to return within **±0.5σ** (`REBOUND_BAND_SD = 0.5`) of pre-travel recovery baseline mean (capped + flagged if never), no-travel → empty + message, `<14` days → insufficient, disclaimer present.
+
+**Verification:** `npm test -- tests/tools/detect-travel-impact.test.ts`
+
+**Dependencies:** 16a, 16b
+
+**Files:** `src/tools/detect-travel-impact.ts` (new), `tests/tools/detect-travel-impact.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+#### Task 16k: `generate_report` (+ CSV formula-injection neutralizer)
+
+**Description:** Export a date range as Markdown or CSV, returned **inline as a string** (no disk write by default, D-3). Includes the RFC-4180-safe CSV writer with formula-injection neutralization, written as a reusable exported helper (shared code path for future Tier-4 import per C-1).
+
+**Acceptance criteria:** Implements [spec §Tool 2.4](../specs/v4-personal-analytics.md) bullets, incl. valid Markdown sections/tables, RFC-4180 CSV escaping, cells leading with `= + - @ \t \r` neutralized with `'` (fixture proving a legit `-5` is made inert, not corrupted), `sections` filter, inline-only (no implicit disk write), report body length bounded per `capDataPoints`/summary-first (M-2), empty range → "no data" notices not error, disclaimer in body.
+
+**Verification:** `npm test -- tests/tools/generate-report.test.ts`
+
+**Dependencies:** 16b (uses pagination/day-key + report assembly)
+
+**Files:** `src/tools/generate-report.ts` (new), `tests/tools/generate-report.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+### Checkpoint 2: Tier 2 Complete (after 16h–16k)
+- [ ] `npm test` green; `npm run lint && npm run typecheck && npm run build` clean
+- [ ] All 4 Tier 2 tools registered; disclaimer present on each interpretive output
+- [ ] CSV neutralizer fixtures pass (formula leads + negative-number non-corruption)
+- [ ] No implicit disk writes from `generate_report`
+
+---
+
+### Phase 3 — Tier 3 Reconcile
+
+> **Split rationale:** `correlate_metrics` is genuinely XL — the arbitrary-pair engine + 5-preset
+> reproduction + `.refine()` is one shippable unit; the two **derived-series** presets
+> (rolling-7-day bedtime-stddev series; workout-keyed recovery-delta) are each a distinct pipeline.
+> They land as two tasks so each leaves the suite green. 16l-b extends the same tool file/schema
+> registered in 16l-a (the preset enum is complete from the start; 16l-b fills in the two derived
+> branches), so there is no second `server.ts` registration.
+
+#### Task 16l-a: `correlate_metrics` — core (arbitrary pair + 3 scalar presets)
+
+**Description:** The full tool surface: Zod schema with the complete `preset` enum + `x_metric`/`y_metric`/`lag_days` pair path, `.refine()` mutual-exclusion, wake-day alignment, the correlation engine, and the **3 scalar presets** expressible as plain metric pairs. The 2 derived presets are wired to return a clear "not yet implemented" guard until 16l-b (or are gated out of the enum until 16l-b — implementer's choice, documented).
+
+**Acceptance criteria:** Implements the arbitrary-pair half of [spec §Tier 3](../specs/v4-personal-analytics.md), incl. `.refine()` mutual-exclusion (preset XOR x/y pair; lone `x_metric` rejected), shared wake-day alignment with `lag_days` (recovery keyed via cycle per 16b — fetches cycles), reuse `pearsonR`/`correlationStrength`/`correlationDirection`/`isSignificant`, self-correlation (`x===y && lag===0`) rejected, zero-variance → r=0/none, `<7` paired points → insufficient, `p_significant` via `R_CRITICAL_TABLE`, **3 scalar presets reproducible** via the pair path, `data_points` capped (M-2), disclaimer present.
+
+**Verification:** `npm test -- tests/tools/correlate-metrics.test.ts`
+
+**Dependencies:** 16a, 16b (recommended: after 16g)
+
+**Files:** `src/tools/correlate-metrics.ts` (new), `tests/tools/correlate-metrics.test.ts` (new), `src/server.ts` (register)
+
+**Estimated scope:** Medium (3 files)
+
+---
+
+#### Task 16l-b: `correlate_metrics` — derived-series presets
+
+**Description:** Implement the two derived-series presets that cannot be expressed as a scalar pair: `sleep_consistency_vs_hrv` (X = rolling 7-day std-dev of bedtime) and `workout_strain_vs_recovery_drop` (Y = day-before → day-after recovery delta, keyed on workouts). Extends the 16l-a tool file; no new registration.
+
+**Acceptance criteria:** Both derived presets reproduce the legacy `get_correlations` semantics (back-compat, no regression), `sleep_consistency_vs_hrv` enforces `days >= 21` (7-day warmup + 14 pairs), workout-keyed delta alignment correct, insufficient-data paths covered, `data_points` capped, disclaimer present. **All 5 presets now reproducible.**
+
+**Verification:** `npm test -- tests/tools/correlate-metrics.test.ts`
+
+**Dependencies:** 16l-a
+
+**Files:** `src/tools/correlate-metrics.ts` (modify), `tests/tools/correlate-metrics.test.ts` (modify)
+
+**Estimated scope:** Medium (2 files; fixture-heavy derived-series math)
+
+---
+
+### Checkpoint 3: Tier 3 Complete (after 16l-a, 16l-b)
+- [ ] `npm test` green; all 5 presets reproduce expected results with annotated fixtures
+- [ ] Mutual-exclusion + self-correlation rejections covered
+- [ ] `npm run lint && npm run typecheck && npm run build` clean
+
+---
+
+### Phase 4 — Release Wiring
+
+#### Task 16m: cross-tool tests, version bump, docs, full verification
+
+**Description:** Wire up the release: shared cross-cutting tests, version/label, and docs. Reflects
+the D-1 decision (default `0.6.0`).
+
+**Acceptance criteria:**
+- [ ] **GATE: D-1 is resolved by the human before any version/CHANGELOG/README edit.** This task hardcodes nothing until then; `0.6.0` is the default pending confirmation.
+- [ ] **Shared disclaimer test** — one parametrized test asserts every new interpretive tool's output carries the exact canonical disclaimer string.
+- [ ] **Server-registration integration test** — asserts all ~10 new tools are registered with unique `snake_case` names and valid Zod input schemas (catches an implemented-but-unwired tool).
+- [ ] `package.json` version → `0.6.0` (or the human's D-1 choice); `CHANGELOG.md` entry added.
+- [ ] `README.md` tool count and tool list updated (14 → 24).
+- [ ] No new runtime dependencies in `package.json`; no new OAuth scopes in the auth request.
+- [ ] Coverage thresholds met: `stats-utils.ts` and new analytics tools > 80%; overall > 70%.
+- [ ] `CLAUDE.md` / `.github/copilot-instructions.md` implementation-status updated.
+
+**Verification:** `npm test && npm run typecheck && npm run build && npm run lint` (+ `npm test -- --coverage`)
+
+**Dependencies:** 16a–16l-b
+
+**Files:** `tests/server.test.ts` (modify), `tests/tools/disclaimer.test.ts` (new), `package.json`, `CHANGELOG.md`, `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md`
+
+**Estimated scope:** Medium (docs + 2 test files)
+
+---
+
+### Checkpoint: Release Ready (after 16m)
+- [ ] All acceptance criteria across 16a–16m met
+- [ ] D-1 reflected in `package.json` + `CHANGELOG.md`
+- [ ] Tool count updated everywhere (14 → 24)
+- [ ] `npm test && npm run typecheck && npm run build && npm run lint` clean; coverage met
+- [ ] Tier 4 confirmed out of scope (tracked separately, gated on security audit per D-5)
+- [ ] Ready for human review / release
+
+---
+
+## Parallelization Opportunities
+
+| Can run in parallel | Must be sequential |
+|---------------------|--------------------|
+| 16a ∥ 16b (different files) | 16a/16b before any tool |
+| 16c–16g **tool files + test files** (logic is independent) | The `src/server.ts` registration edits for all tools (shared file) |
+| 16h–16i–16j–16k **tool files + test files** | 16l-b after 16l-a (same file); 16m after all tools |
+
+> **`server.ts` is a shared edit region.** Tool logic and tests parallelize, but every tool task
+> also touches `src/server.ts` (imports + a `registerTool` block). Serialize those edits (or batch
+> all registrations into one wiring step) to avoid merge churn. 16g before 16l-a is a **recommended**
+> ordering (16g exercises the wake-day key first), not a hard import dependency.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Time-dependent tests flaky ("today"/relative ranges) | 🟡 Medium | `vi.useFakeTimers()` with a FIXED system time per spec; restore in `afterEach`. |
+| DST math wrong in sleep-debt / day-of-week / travel | 🟡 Medium | Pin explicit reference offsets; 23h spring-forward + 25h fall-back fixtures (spec testing strategy). |
+| Silent pagination truncation skews baselines | 🟡 Medium | 16b enforces explicit `maxRecords` + `truncated` flag; tool summaries note partial windows. |
+| `correlate_metrics` is XL (engine + 5 presets + 2 derived pipelines) | 🟡 Medium | Split into 16l-a (core + 3 scalar presets) and 16l-b (2 derived presets); each ships green. |
+| **Wake-day key diverges from UTC-keyed `get-calendar`/`get-today`/`get-weekly-summary`** | 🟡 Medium | The new offset-local key is intentionally different; 16b documents the divergence in the helper doc-comment; a follow-up may migrate the UTC-keyed tools. Cross-check expected day assignment in fixtures. |
+| Recovery can't be local-day-keyed alone (no offset on the record) | 🟡 Medium | 16b helper takes cycle context and keys recovery via `cycle_id`; 16c/16g/16l-a fetch cycles alongside recovery. |
+| Coverage dips below 80% on heavy-branch tools | 🟢 Low | Spec holds stats-utils + analytics tools to >80%; checkpoint gate in 16m. |
+
+---
+
+## Open Questions (carried from spec; block final scope)
+
+| ID | Question | Plan default |
+|----|----------|--------------|
+| D-1 | Ship as `0.6.0` (Option A) or force `0.5.3`? | `0.6.0` — affects 16m version string only |
+| D-2 | Tier 1+2+3 in-release, Tier 4 deferred? | Yes — Tier 4 not in this plan |
+| D-3 | `generate_report` disk write? | No — inline string only (16k) |
+| D-4 | `correlate_metrics` supersedes `get_correlations`? | Yes — nothing live to deprecate (16l-a) |
+| D-5 | Tier 4 deferred to a separate gated plan? | Yes — security audit first |
+
+## Out of Scope (this plan)
+
+- **Tier 4** — `log_behavior`, behavior store, WHOOP CSV import/correlation. Separate gated plan pending security audit (spec D-5).
+- **Webhooks** — pushed to `0.7.0` per spec Option A.
+- **`generate_report` disk write** — only if D-3 flips to yes (would require a sandboxed dir + traversal rejection + security review).
+
+## Acceptance Definition
+
+This plan is "done" (ready to implement) when:
+1. The human has resolved D-1 through D-5 (or accepted the defaults above).
+2. `code-reviewer` and `test-engineer` sub-agents have reviewed this breakdown (see review note below).
+3. The human approves the task order and scope.
+
+---
+
+## Sub-Agent Review Note (2026-06-11)
+
+`code-reviewer` reviewed this breakdown against the live codebase; findings incorporated:
+
+| Finding | Severity | Resolution in this plan |
+|---------|----------|-------------------------|
+| `get-calendar` keys by **UTC** (`iso.slice(0,10)`), not `timezone_offset` — "reuse" premise false | Critical | Decision 7 rewritten: wake-day key is net-new offset-local logic; documents divergence; risk re-rated Medium. |
+| `Recovery` has no offset → can't be local-day-keyed alone | Important | 16b helper takes cycle context (keys via `cycle_id`); 16c/16g/16l-a fetch cycles. |
+| `correlate_metrics` is genuinely XL | Important | Split into 16l-a (core + 3 scalar presets) and 16l-b (2 derived presets). |
+| `data_points` cap (M-2) only wired into correlate | Important | Added `capDataPoints` to 16e, 16g, 16k acceptance. |
+| Parallelization overstated — all tools edit `src/server.ts` | Important | Parallelization table corrected: tool/test files parallel, `server.ts` edits serialized. |
+| `ABSOLUTE_MAX_RECORDS`/`truncated` already exist in `pagination.ts` | Minor | 16b imports/wraps them, does not redefine. |
+| No existing tool emits a disclaimer; "identical to v3" moot | Minor | Decision 8 added: `DISCLAIMER` is established net-new here, no competing convention. |
+| 16g-before-16l is a test-confidence preference, not a hard dep | Minor | Re-labeled "recommended ordering" in graph + parallelization note. |
+| Plan hardcodes `0.6.0` while D-1 pending | Minor | 16m gains an explicit D-1-resolved gate before any version/doc edit. |
+
+**Confirmed sound by the reviewer:** foundation-first ordering (16a/16b), vertical-slice integrity (each tool task leaves the system green), and keeping the CSV neutralizer with `generate_report` rather than hoisting it to foundation (correct YAGNI given Tier 4 is deferred).
+
+`test-engineer` could not read files in its session (tooling limitation), so the test-strategy axis was validated directly against the spec's Testing Strategy section and the confirmed `tests/tools/` layout: every task's verification command maps to a real `tests/tools/*.test.ts` path; property tests (16a), fake-timers + DST fixtures (16e/16g/16j), the shared disclaimer test and server-registration test (16m), and the >80%/>70% coverage gate (16m) all trace to spec requirements. Open follow-up for implementers: `stats-utils` currently lacks `Number.isFinite` guards on inputs (NaN can propagate) — 16a should add finite-input guards to the new functions to honor the "no NaN" contract.

--- a/docs/plans/task-17-v070-trustworthy-personal-analytics.md
+++ b/docs/plans/task-17-v070-trustworthy-personal-analytics.md
@@ -1,0 +1,51 @@
+# Task 17: Trustworthy Personal Analytics Execution
+
+Approved for implementation: 2026-09-10. Target release: 0.7.0, not yet published.
+Contract: [release spec](../specs/v070-trustworthy-personal-analytics.md).
+
+## Increment Status
+
+1. [x] Current-day regression and score-state guard. Verified pending primary sleep
+       suppresses recovery. Check: `npm test -- tests/tools/get-today.test.ts`.
+2. [x] Bounded selection, ID joins, recorded-offset days and quality metadata.
+       Verified stale/mismatched/invalid records, partial endpoints, null scores and open cycles.
+       Preserved legacy duration; added asleep/time-in-bed fields.
+3. [x] Shared analytics validation, percentile and circular-clock primitives.
+       Existing paginator reused with page validation and a 500-record cap.
+       Check: `npm test -- tests/tools/analytics-utils.test.ts`.
+4. [x] Personal baselines and sleep debt with synthetic fixtures and insufficient-data
+       behavior. Check: `npm test -- tests/tools/get-baselines.test.ts tests/tools/get-sleep-debt.test.ts`.
+5. [x] Schema-validated MCP results and aggregate-only registration/projections.
+       Check: `npm test -- tests/server-release.test.ts tests/server.test.ts tests/resources/index.test.ts`.
+6. [x] Local diagnostics and early process privacy validation.
+       Check: `npm test -- tests/cli/doctor.test.ts tests/index.test.ts`.
+7. [x] Real stdio child-process and authenticated HTTP parity with synthetic data.
+       Check: `npm test -- tests/transport/stdio-mcp-integration.test.ts tests/transport/http-mcp-integration.test.ts`.
+8. [x] Targeted compatible lockfile advisory fixes; no dependency range changes.
+       Runtime audit is clean; development-only moderate Vitest advisory remains.
+9. [x] README migration guidance, unreleased changelog, spec status and backlog linkage.
+10. [x] Site release preview and local [PR description](../reviews/v070-pr-description.md).
+        Published 0.6.1 installation is distinct from upcoming 0.7.0 capabilities.
+        Browser layout checked at 1440px, 390px and 320px; no horizontal overflow,
+        valid internal anchors and matching displayed/copied installation commands.
+
+## Release Gates
+
+- [x] Implementation increments tested before proceeding; no tests deleted or skipped.
+- [x] Code/security self-review fixes applied: invalid-newest fallback, date-clock injection,
+      malformed page classification, nullable scores, resource error redaction and aggregate timestamp minimization.
+- [x] Final formatting, full test/coverage, lint, typecheck and build pass recorded:
+      797 tests across 43 files; 95.61% line coverage overall, 98.84% API and 99.18% auth.
+      `npm run format:check` and `git diff --check` also pass.
+- [x] Built `node dist/index.js doctor --json` smoke-tested. It correctly reports
+      missing shell credentials without network calls; local token-file metadata checks pass.
+- [ ] Manual Claude Desktop or VS Code client smoke check: standard discovery, structured
+      result display, JSON-text fallback, then aggregate discovery after reconnect.
+- [ ] Human release review, version metadata bump and publishing authorization.
+      Synchronize package, lockfile and MCP registry versions at release time;
+      the registry descriptor currently retains its historical 0.6.0 version.
+
+The automated transport checks are not a claim that a desktop client's UI was
+manually exercised. No WHOOP health API calls were made in automated tests.
+Creating the feature branch and PR does not publish a package. Publication requires
+separate authorization after the remaining release gates are complete.

--- a/docs/reviews/v070-implementation-review.md
+++ b/docs/reviews/v070-implementation-review.md
@@ -1,0 +1,71 @@
+# 0.7.0 Implementation Review
+
+Date: 2026-09-10. Scope: approved trustworthy-core plus baseline/sleep-debt implementation.
+This is an implementation self-review and dependency triage, not an independent audit.
+
+## Findings Addressed
+
+- Correctness: latest records are no longer independently combined into a current-day
+  recovery. Pending/invalid primary sleep, missing joins, stale cycles, null provider
+  fields and endpoint failures have explicit regression coverage.
+- Correctness: relative sleep windows use the supplied clock. Stage sums and signed
+  nap adjustments determine observed deficits; WHOOP standing debt stays separate.
+- Security: aggregate mode fails closed at registration and uses per-tool schemas to
+  project allowed fields. Record arrays, latest observations, identity fields and exact
+  record timestamps are excluded. Resources/prompts cannot bypass the allowlist.
+- Security: tool and resource errors no longer echo provider bodies or arbitrary
+  exception messages. Local diagnostics inspect metadata only and never perform OAuth.
+- Architecture: existing API client, paginator, statistics and transports are reused.
+  No new endpoint, OAuth scope, runtime dependency or persisted health store was added.
+- Performance: today remains four parallel bounded calls; analytics uses at most
+  500 records per source, honors paginator delays/caps, and bounds echoed nights at 30.
+- Readability: schemas are shared for validation/output and pure helpers centralize
+  local-day attribution, source quality, main-sleep selection and statistical conventions.
+
+## Dependency Triage
+
+Before remediation, npm reported 15 findings: two critical, seven high, four moderate,
+two low. Targeted `npm update` of identified vulnerable packages within existing
+ranges refreshed the lockfile; manifest ranges and direct dependency count did not change.
+
+After remediation, `npm audit --omit=dev` reports zero vulnerabilities. The full audit
+reports three moderate package entries (`vitest`, `@vitest/mocker`, and
+`@vitest/coverage-v8`) for one underlying
+[redirect-mock file-read advisory](https://github.com/advisories/GHSA-82fw-gwwq-j7x9).
+These are development-only, excluded from the published runtime. The audit's suggested
+fix is a major Vitest migration; the advisory identifies fixed versions at 4.1.11+.
+No major upgrade or risk suppression was applied. Avoid exposing development/test servers
+to untrusted clients; schedule a separate test-runner migration.
+
+## Verification Sources
+
+Final automated verification: 797 tests in 43 files; 95.61% overall line coverage,
+98.84% API and 99.18% auth. Lint, typecheck, build, format check and whitespace
+checks pass. Both real stdio subprocess and HTTP transport tests use synthetic data.
+The built doctor command was smoke-tested without network access.
+
+- [MCP output schemas and structured content](https://modelcontextprotocol.io/specification/2025-11-25/server/tools).
+- [Zod object parsing and unknown-key stripping](https://zod.dev/api#objects).
+- [WHOOP member API](https://developer.whoop.com/api).
+- [Execution and release checklist](../plans/task-17-v070-trustworthy-personal-analytics.md).
+
+## Residual Limitations
+
+Recorded offsets cannot infer future timezone rules or within-sleep DST transitions.
+Old calendar/weekly-summary grouping stays UTC. Fetch timestamps/cache hits remain
+unknown where the client lacks that metadata. Whole malformed records are conservatively
+excluded from new analytics; no attempt is made to reconstruct corrupted measurements.
+Health aggregates remain sensitive and still reach the assistant provider.
+Manual desktop-client display checks and release authorization remain outstanding.
+
+## PR Documentation And Site Check
+
+README and changelog describe the unreleased 0.7.0 scope and compatibility changes;
+historical npm comparison entries remain labeled as published 0.6.1 information.
+The site retains its existing design while adding a release preview, data-quality
+and privacy notes, and accurate published-install instructions. Browser checks at
+1440px, 390px and 320px found no horizontal overflow or missing internal anchors.
+The 320px header was adjusted to wrap navigation instead of the product wordmark.
+No browser page errors were observed on reload. The tracked favicon is present.
+Copy-button payloads match the displayed commands; clipboard write permissions
+were not altered or bypassed during testing.

--- a/docs/reviews/v070-pr-description.md
+++ b/docs/reviews/v070-pr-description.md
@@ -1,0 +1,66 @@
+# PR: Add Trustworthy Personal Analytics And Aggregate Privacy
+
+## Summary
+
+Prepare the approved 0.7.0 feature scope without publishing or changing package
+version metadata beyond the previously local 0.6.1 baseline. Standard mode offers 16 tools, four resources and five prompts.
+Aggregate mode exposes only five summary/analytics tools.
+
+This branch also includes the two previously local baseline commits: the 401
+error/token-persistence fix and the 0.6.1 version update. It does not bump to 0.7.0.
+
+- Add personal baseline distributions and sleep-debt analysis with explicit sample
+  counts, bounded history, baseline self-exclusion and insufficient-data states.
+- Match current-day recovery to its cycle and primary sleep. Suppress stale,
+  pending, invalid or unjoinable results instead of substituting older scores.
+- Advertise output schemas and return equivalent structured content and JSON text.
+- Enforce process-level aggregate privacy at registration and output boundaries;
+  sanitize tool/resource errors and minimize exact-record metadata.
+- Add local-only `doctor` diagnostics and compatible dependency advisory fixes.
+- Update README, changelog and site together. The site explicitly distinguishes
+  upcoming 0.7.0 functionality from the published 0.6.1 install commands.
+
+## Compatibility
+
+- Default mode remains `standard`; existing tool names and input defaults remain.
+- `get_today.sleep.total_hours` retains time-in-bed semantics. New
+  `time_in_bed_hours` and `asleep_hours` fields are explicit; summaries use asleep time.
+- Missing optional sleep percentages now return null, not zero.
+- `WHOOP_MCP_PRIVACY_MODE=aggregate` hides raw tools, resources and incompatible
+  prompts. Tool arguments cannot override the policy; reconnect after changing it.
+- Calendar/weekly-summary UTC grouping stays unchanged. New analytics uses recorded
+  offsets; these cannot reconstruct future timezone rules or within-sleep DST changes.
+- No new direct runtime dependency, WHOOP endpoint, OAuth scope or persisted health store.
+- Remaining Task 16 analytics, forecasts, webhooks, UI apps and local databases are not included.
+
+## Verification
+
+- [x] 797 tests across 43 files; all WHOOP responses in automated tests are synthetic.
+- [x] Real stdio subprocess and authenticated HTTP contract/privacy tests.
+- [x] Lint, typecheck, build, source/test formatting and whitespace checks.
+- [x] Coverage: 95.61% overall lines, 98.84% API, 99.18% auth.
+- [x] Production dependency audit: zero findings after targeted compatible updates.
+- [x] Built local-only diagnostics smoke test; no OAuth or health API calls.
+- [x] Site browser checks at 1440px, 390px and 320px: no horizontal overflow,
+      valid internal anchors, matching copy-command payloads, desktop/mobile screenshots.
+
+## Known Risks And Release Follow-Ups
+
+- Three moderate development-only Vitest audit entries remain for the redirect-mock
+  advisory. Remediation requires a separate major-version migration; do not expose
+  test/development servers to untrusted clients.
+- [ ] Manually verify Claude Desktop or VS Code display/discovery in both privacy modes.
+- [ ] Complete human release review, then synchronize package, lockfile and MCP registry
+      version metadata to 0.7.0 and authorize publication. Existing registry metadata is 0.6.0;
+      package metadata is 0.6.1. Neither is bumped in this feature PR preparation.
+
+References: [release specification](https://github.com/shashankswe2020-ux/whoop-mcp/blob/feature/v070-personal-analytics/docs/specs/v070-trustworthy-personal-analytics.md),
+[execution checklist](https://github.com/shashankswe2020-ux/whoop-mcp/blob/feature/v070-personal-analytics/docs/plans/task-17-v070-trustworthy-personal-analytics.md),
+[implementation review and security triage](https://github.com/shashankswe2020-ux/whoop-mcp/blob/feature/v070-personal-analytics/docs/reviews/v070-implementation-review.md).
+
+## Scope Note
+
+Supporting analytics/coaching drafts are included as historical design context,
+not as additional implemented scope. Pre-existing edits to the Task 14 and Task 15
+plans and the general implementation plan are left outside this PR. No package
+publication is performed by opening this PR.

--- a/docs/specs/v070-trustworthy-personal-analytics.md
+++ b/docs/specs/v070-trustworthy-personal-analytics.md
@@ -1,0 +1,235 @@
+# Next Release: Trustworthy Personal Analytics
+
+> Status: approved by the user on 2026-09-10; implemented in the working tree, not published.
+> Proposed release: `0.7.0`, from shipped package `0.6.1`.
+> Date: 2026-09-10.
+> Baseline: 14 tools, four resources, five prompts; 750 tests passing.
+> Evidence: [September SOTA scan](../ideas/sota-feature-scan-2026-09-10.md).
+
+## Objective
+
+Deliver trustworthy current-day answers plus two descriptive analytics tools:
+`get_baselines` and `get_sleep_debt`. Users should be able to ask "Is this current?",
+"Is this typical for me?" and "How much sleep have I missed?" without receiving
+stale scores, invented zero values or unsupported medical interpretations.
+
+The user selected **core plus personal analytics**. This proposal includes structured
+results, freshness/pending-score safeguards, opt-in privacy controls, local diagnostics,
+personal baselines and sleep debt. It does not expand the release to every SOTA idea.
+
+## Assumptions And Scope
+
+- Keep the SDK and Zod as the only direct runtime dependencies; no new WHOOP endpoints,
+  scopes, OAuth behavior, token storage formats or persisted health data.
+- Propose `0.7.0` as the next minor release; do not bump package metadata until release verification.
+- Standard mode retains the existing 14 tools, four resources and five prompts.
+  Adding the two tools makes 16 tools; do not add separate tools for shared metadata.
+- Share calculations through pure helpers, not tool-to-tool calls. Reuse pagination,
+  error types and cache primitives. Never create a second statistical engine.
+- The new spec controls this release once approved. The broader
+  [Task 16 plan](../plans/task-16-v4-personal-analytics.md) remains the analytics backlog.
+  Only the necessary subset of 16a/16b, plus 16d and 16e, belongs here.
+
+## Compatibility And Structured Results
+
+- Every successful tool result supplies schema-validated `structuredContent` and a
+  JSON text block encoding the same object. Each tool advertises its `outputSchema`.
+- Preserve existing tool names, input defaults and existing output fields in standard
+  mode. Do not wrap old payloads in a new `data` envelope. Metadata is additive.
+- Keep `isError: true` semantics for failures; never disguise errors as valid measurements.
+  Errors must not include tokens, upstream response bodies or health records.
+- Missing data is `null` with an explicit reason, not zero. `get_today` optional sleep
+  performance/efficiency fields becoming nullable is an intentional contract correction,
+  documented in migration notes and tested with legacy JSON-text clients.
+- Retain `get_today.sleep.total_hours` as the legacy time-in-bed value for compatibility;
+  add `time_in_bed_hours` and `asleep_hours` with unambiguous units. Summary text uses
+  asleep time, computed as light + slow-wave + REM, excluding awake/no-data time.
+- Validate external fields used by new analytics and current-day selection at their
+  boundary; malformed/non-finite observations are excluded with counted reasons.
+
+## Shared Evidence Contract
+
+Use an additive `data_quality` object for `get_today` and the two new tools:
+
+- `evaluated_at`: computation time, never presented as upstream fetch time.
+- `requested_period` and `observed_period`: explicit ISO bounds; observed is null when empty.
+- Per-source metadata: nullable `fetched_at`, nullable `source_updated_at`, records
+  fetched/used, exclusion counts, `truncated`, and cache status `hit`, `miss` or `unknown`.
+- If the existing client cannot provide an actual fetch timestamp or cache status,
+  return null/unknown. Do not substitute computation time or infer cache hits.
+- Status/reasons distinguish `available`, `pending`, `missing`, `stale`, `unscored`,
+  `calibrating`, `invalid` and `fetch_failed`; partial results name unavailable sources.
+- Units, method version and limitations accompany derived metrics. No arbitrary
+  percentage "confidence" scores or clinical risk labels.
+- Keep raw source IDs out of new metadata by default. Correlation of records uses IDs
+  internally; provenance exposed to users is limited to source domains and time windows.
+
+## Current-Day Safeguards
+
+- Select the current cycle and latest relevant non-nap primary sleep from bounded
+  collections, not independent `records[0]` values. Join recovery using both
+  `cycle_id` and `sleep_id` where corresponding records are available.
+- Current recovery requires a matching current cycle and primary sleep. A newest
+  pending primary sleep suppresses older recovery; a missing join never falls back
+  to an unrelated score. Endpoint failure remains distinct from absent data.
+- Compare local days using each record's offset and an injected clock. If cycle
+  context is unavailable, mark recovery missing/unverifiable rather than guessing.
+  An offset describes recorded local time, not an IANA zone or future DST rules.
+- Require `score_state === "SCORED"` for score-derived metrics; calibration is explicit
+  and suppresses baseline-relative interpretation. Do not coerce missing scores to zero.
+- Keep latest workout separately labeled as historical context with its occurrence
+  time; never imply it occurred today merely because it is the latest workout.
+- Preserve useful partial responses; all three primary sources failing still raises
+  a typed failure. No raw provider error text reaches the assistant.
+- Verification fixtures: pending sleep plus older scored recovery; a latest nap;
+  mismatched IDs; stale cycle; missing score; near-local-midnight; endpoint failures;
+  and in-bed duration different from scored asleep duration.
+
+## Personal Baselines
+
+Implement `get_baselines` from [the analytics draft](v4-personal-analytics.md), with
+these clarifications taking precedence over conflicting historical comments:
+
+- Input: `baseline_days`, integer 14-180, default 30. Analyze HRV, resting HR,
+  respiratory rate, asleep hours and recovery score using existing read scopes.
+- Identify the latest eligible observation per metric, then exclude that observation
+  and the current local day from the comparison distribution. Exclude calibration,
+  non-SCORED data and invalid numeric values. Sleep uses one main non-nap sleep per wake day.
+- Require at least 14 valid historical observations per metric after exclusions.
+  Otherwise return a null band with sample count and an insufficient-data reason.
+- Provide mean, median, standard deviation and p10/p25/p50/p75/p90 using linear
+  interpolation. Latest percentile uses midrank: `100 * (below + 0.5 * equal) / count`.
+  A constant baseline gets `constant_baseline: true`, not a claim of normality.
+- Join recovery to cycles for local-day attribution. Missing cycle context excludes
+  that observation and is counted; never use recovery update time as the physiological day.
+- Report actual observed bounds, explicit truncation and the canonical disclaimer.
+  No population norms, diagnosis, anomaly alerts or causal interpretations.
+- Tests cover interpolation endpoints, ties, no self-inclusion, calibration,
+  missing joins, metric-specific insufficiency, constant data and pagination caps.
+
+## Sleep Debt
+
+Implement `get_sleep_debt` from the analytics draft, with these pinned semantics:
+
+- Input: `days`, integer 3-90, default 14; optional `start` accepts the existing
+  ISO/relative-date parser. `start` anchors a window of `days` calendar days;
+  without it use the last `days` days. Clamp to evaluation time and reject future
+  or empty ranges. Return resolved bounds so the assistant can inspect the choice.
+- Use the longest SCORED non-nap sleep by elapsed duration per local wake day;
+  break ties by latest end, then stable ID. Exclude invalid records with counted reasons.
+- Needed hours = baseline + recent strain + recent nap, preserving the nap field's
+  sign and excluding WHOOP's accumulated sleep-debt component.
+- Achieved hours = scored asleep stages. Daily deficit is `max(0, needed - achieved)`.
+  `total_debt_hours` is the sum of observed nightly deficits, not outstanding debt
+  or a prediction of how much extra sleep will restore recovery.
+- Return WHOOP's latest standing debt separately as `standing_debt_hours` when present,
+  with its source date; never derive it from the window sum.
+- Fewer than three usable nights produces insufficient-data status and null aggregates,
+  not zero debt. Missing nights are not treated as zero-sleep nights.
+- Use circular clock-time statistics for bedtime, wake time and midpoint comparisons.
+  Social jetlag is the shortest circular distance between weekday/weekend mean
+  midpoints; null if a group is absent or its circular mean is undefined.
+- Use elapsed timestamps for durations and recorded offsets for local clock labels.
+  Document that a single offset cannot reconstruct within-sleep DST changes.
+- Compute aggregates on the full bounded dataset; expose at most 30 nightly records,
+  with separate output-cap and upstream-truncation flags. Canonical disclaimer required.
+- Fixtures cover naps, signed nap adjustment, debt double counting, stage sums,
+  midnight clock wrapping, DST-adjacent records, missing groups, missing nights and caps.
+
+## Privacy Controls
+
+- Add process-level `WHOOP_MCP_PRIVACY_MODE=standard|aggregate`, default `standard`.
+  Validate before registration. Tool arguments and prompts cannot override this policy.
+- Aggregate mode exposes only an allowlist of aggregate-capable tools: weekly summary,
+  period comparison, trend, baselines and sleep debt. Return aggregate fields only:
+  no profile/body details, raw records, per-day arrays, latest observations, individual
+  source IDs, email/name or exact activity timestamps. Analysis-window dates are allowed.
+- Do not register individual-record, collection, today or calendar tools in aggregate
+  mode; reject direct calls too. Disable the four raw resources. Filter prompts whose
+  workflows require disabled tools; do not promise unavailable capabilities.
+- Use per-tool allowlisted output projections, not generic recursive key deletion.
+  Generate summaries only from allowed fields. New tools remain unavailable in aggregate
+  mode until an explicit projection and leakage test exist.
+- The same projected object feeds structured and text results. Cover HTTP and stdio,
+  resource reads, tool discovery/direct calls, prompt retrieval and error paths.
+- Document that aggregate health data still reaches the assistant provider. This is
+  minimization, not anonymization, and does not erase data already shared with a client.
+
+## Local Diagnostics
+
+- Add `whoop-ai-mcp doctor` with readable output and `--json` for scripts.
+- Check runtime, required configuration presence, configured transport/privacy mode
+  and token-file presence/permissions without fetching WHOOP data, opening a browser,
+  refreshing tokens, rewriting files or printing configuration values/token paths.
+- Do not claim granted scopes or token validity from configuration alone. Unknown
+  values remain unknown. Direct users to existing `setup --verify` for explicit live checks.
+- Exit 0 for locally ready, 1 for remediation needed, 2 for invalid invocation.
+  Tests inject filesystem/configuration dependencies and assert zero network/auth calls.
+- Synthetic demo and generic CLI tool calls are later work, not release requirements.
+
+## Delivery Boundaries
+
+Deferred: anomaly alerts, training-load risk categories, correlations, weekday/workout
+analytics, coaching forecasts, benchmarks, report export, MCP Apps, webhook receivers,
+offline databases, behavior journals, CSV import and experimental MCP tasks.
+
+Existing calendar/weekly-summary UTC grouping is not silently migrated in this release.
+Label their convention explicitly and document its difference from new offset-local
+analytics. A cross-tool date migration requires its own approved compatibility contract.
+
+## Engineering Conventions
+
+Use strict TypeScript, named exports, explicit exported return types and kebab-case
+files. Co-locate new tool schemas and handlers; mirror source files under `tests/`.
+Follow the current pattern:
+
+```typescript
+export async function getToday(client: WhoopClient): Promise<TodaySnapshot>;
+```
+
+Keep orchestration in tool handlers, pure statistics in `src/tools/stats-utils.ts`,
+and date/quality conventions in a small shared analytics helper. Wire registrations
+through `src/server.ts`, process configuration through `src/index.ts`, and diagnostics
+under `src/cli/`. Do not build unused correlation primitives for this release.
+
+## Testing And Release Gates
+
+Use Vitest and mocked WHOOP fetches. Write failing tests before behavior changes;
+test pure statistics first, then handler fixtures and in-memory MCP contracts.
+Run `npm test` after each increment. Keep existing tests and add documented assertions
+for intentional compatibility corrections rather than deleting failing cases.
+
+```sh
+npm test -- tests/tools/get-today.test.ts tests/server.test.ts
+npm test
+npm run lint
+npm run typecheck
+npm run build
+npm test -- --coverage
+```
+
+- All output schemas match returned structured results and serialized text; both
+  new tools are registered in standard mode with unique names and bounded inputs.
+- Standard/aggregate capabilities match their documentation; no forbidden-field
+  leakage across any exposed surface, including errors and resource access.
+- Maintain >80% auth/API coverage and >70% overall; do not remove or skip failures.
+- Triage the scan's 15 npm advisories, including two critical, against the current
+  lockfile. Unresolved applicable high/critical issues block release absent explicit
+  documented risk acceptance. No blind `npm audit fix` or major dependency upgrades.
+- Run code/security review and manual supported-client checks for structured results,
+  JSON-text fallback and aggregate-mode discovery before packaging.
+- Update README, changelog and client migration notes only with implemented behavior.
+  Version metadata changes happen after gates pass; publishing/committing needs approval.
+
+## Approval And Execution
+
+The user approved the release contract and requested implementation on 2026-09-10.
+See the [execution checklist](../plans/task-17-v070-trustworthy-personal-analytics.md)
+for implemented slices and outstanding release gates. Package metadata remains at
+0.6.1 until manual client smoke checks and release authorization are complete.
+
+Aggregate output omits observed-record timestamps and source-update timestamps;
+exposed period bounds are reduced to calendar dates. All five existing prompts
+depend on excluded raw capabilities and are therefore unavailable in aggregate mode.
+No new aggregate prompt was added. Existing raw resource payloads remain unchanged
+in standard mode, but their errors are sanitized.

--- a/docs/specs/v4-personal-analytics.md
+++ b/docs/specs/v4-personal-analytics.md
@@ -1,0 +1,918 @@
+# Spec: WHOOP MCP Server — V4 Personal Baseline Analytics
+
+> **Status:** Draft (awaiting human approval + sub-agent review)
+> **Requested label:** `0.5.3`
+> **Recommended label:** `0.6.0` (see [Versioning Decision](#versioning-decision) — these are features, not a patch)
+> **Date:** 2026-06-11
+> **Baseline:** v0.5.2 shipped — 14 tools, 4 resources, 5 prompts, 716 tests, lint/typecheck/build clean
+> **Prior specs:** [v2-feature-enhancements.md](./v2-feature-enhancements.md), [v3-platform-enhancements.md](./v3-platform-enhancements.md)
+> **Source of requirements:** r/whoop community pain-point synthesis (recurring post genres) cross-checked against the WHOOP v2 public API surface (profile, body measurement, cycles, recovery, sleep, workouts).
+
+## Revision Log
+
+- **2026-06-11 (rev 2)** — Human-review tightenings: (1) `get_training_load` reverted to **coupled** ACWR with explicit coupled-vs-uncoupled + log-scale-strain caveats in `load_note`, plus a `kilojoule` linear-load alternative basis; (2) added `provisional` flag (requires ≥ 21 of 28 SCORED chronic days for a reliable ratio); (3) insufficient chronic data → `acwr_zone: "insufficient_data"` (not "undertraining"); (4) `get_baselines.latest_percentile` now excludes `latest` from its own distribution (convention consistency); (5) `get_sleep_debt` documents `need_from_recent_nap_milli` as negative + adds a nap fixture, achieved pinned to stage sums; (6) `detect_travel_impact` rebound band fixed at ±0.5σ (`REBOUND_BAND_SD`); (7) Tier-4 CSV import reframed — formula-injection is an output guard in `generate_report`, not a parser concern.
+- **2026-06-11 (rev 1)** — Initial draft + `code-reviewer` / `security-auditor` / `test-engineer` findings incorporated (see summary below).
+
+---
+
+## Objective
+
+Add a **personal-baseline analytics layer** to the WHOOP MCP server so AI assistants can answer the questions WHOOP users actually ask — *"Am I getting sick?"*, *"Is my HRV normal for me?"*, *"Am I overtraining?"*, *"How much sleep debt have I built up?"*, *"Why is my Monday recovery always red?"* — grounded in each user's own rolling baseline rather than population averages.
+
+**Target users:** AI assistant users (Claude Desktop, Claude Code, claude.ai web, Cursor) who want their WHOOP data interpreted *relative to their own normal*, not against generic numbers.
+
+**Why this matters (the moat):** Competitors with raw data access don't compute personalized baselines, acute:chronic load ratios, sleep debt, or lagged correlations. WHOOP itself emphasizes that the signal is *your trend vs. your baseline*. These tools turn raw records into the interpretations users want, fully within WHOOP's read-only OAuth API (TOS-compliant, zero ban risk).
+
+**Success looks like:**
+- An assistant can flag an early illness signal (HRV/RHR/respiratory-rate deviation beyond ~2σ of a 30-day baseline) in one tool call.
+- An assistant can state whether today's HRV is normal *for this user* with percentile context.
+- An assistant can report cumulative sleep debt and weekday/weekend consistency ("social jetlag").
+- An assistant can compute an acute:chronic workload ratio and flag sustained low-recovery + high-strain streaks.
+- Every analytical answer carries a clear "not medical advice" disclaimer.
+
+---
+
+## Versioning Decision
+
+The request labels this work **0.5.3**. Per SemVer, adding new MCP tools is a **MINOR** change (new backward-compatible functionality), not a PATCH. The roadmap in `v3-platform-enhancements.md` also already reserves **0.6.0** for `get_correlations` + webhooks.
+
+**Recommendation:** Ship this analytics layer as **0.6.0** and reconcile the overlap:
+
+| Option | Description | Tradeoff |
+|--------|-------------|----------|
+| **A (recommended)** | Ship V4 as **0.6.0**. Fold the planned `get_correlations` into V4 as the generalized `correlate_metrics` (Tier 3). Move webhooks to **0.7.0**. | Cleanest SemVer; one analytics release; resolves the `correlate_metrics`/`get_correlations` duplication. |
+| **B** | Ship V4 as **0.6.0**, keep `get_correlations` *and* `correlate_metrics` separate. | Two overlapping correlation tools — confusing for the model and users. Not recommended. |
+| **C** | Force the **0.5.3** label as requested. | Violates SemVer; collides with reserved 0.6.0; correlation duplication unresolved. |
+
+**This spec is written assuming Option A.** If the human insists on the 0.5.3 label, the tool designs below are unchanged — only the version string and `CHANGELOG` heading differ.
+
+> **OPEN DECISION D-1:** Confirm Option A (ship as 0.6.0, fold correlations in, push webhooks to 0.7.0) vs. forcing 0.5.3.
+
+---
+
+## Assumptions
+
+```
+ASSUMPTIONS:
+1. All required fields exist on the WHOOP v2 API (VERIFIED against src/api/types.ts):
+   - Recovery.score: recovery_score, hrv_rmssd_milli, resting_heart_rate,
+     spo2_percentage?, skin_temp_celsius?
+   - Sleep.score: respiratory_rate?, sleep_performance_percentage?,
+     stage_summary, sleep_needed { baseline_milli, need_from_sleep_debt_milli, ... }
+   - Sleep: start, end, timezone_offset, nap
+   - Cycle.score: strain, kilojoule, average_heart_rate, max_heart_rate
+   - Cycle: start, end?, timezone_offset
+   - Workout.score: strain, kilojoule, zone_durations, average/max_heart_rate
+   - Workout: sport_name, start, end, timezone_offset
+2. No new OAuth scopes needed — existing six read: scopes cover all data.
+3. No new RUNTIME dependencies — pure-TypeScript statistics (extend stats-utils.ts);
+   Node built-ins (node:fs, node:path) only for generate_report file output and
+   the GATED log_behavior store.
+4. Node.js >= 20 remains the minimum (unchanged).
+5. All computation stays in-process. No external DB. The only persistent local
+   state introduced is the GATED behavior log (Tier 4), stored under
+   ~/.whoop-mcp/ with 0600 perms — same directory and permission model as tokens.
+6. The WHOOP journal (alcohol/caffeine/etc.) is NOT exposed by the v2 API. Behavior
+   correlation is therefore a workaround: locally logged behaviors OR an uploaded
+   WHOOP data-export CSV joined against live API data. (Tier 4, gated.)
+7. Auto-pagination (fetchAllPages) and date parsing (date-utils) are reused as-is.
+→ Correct these now or implementation proceeds with these.
+```
+
+---
+
+## Tech Stack (unchanged)
+
+- TypeScript ~5.x (strict, no `any`), Node.js >= 20, native `fetch`
+- `@modelcontextprotocol/sdk`, Zod — no other runtime deps
+- Vitest, ESLint, Prettier; build via `tsc`
+
+## Commands (unchanged)
+
+```bash
+npm run build        # tsc
+npm test             # vitest run
+npm test -- --coverage
+npm run lint
+npm run typecheck
+npm run dev
+```
+
+---
+
+## Release Scope & Tiers
+
+| Tier | Tools | Storage | Scopes | Status in this spec |
+|------|-------|---------|--------|---------------------|
+| **1 — Core** | `detect_anomalies`, `get_baselines`, `get_sleep_debt`, `get_training_load`, `get_day_of_week_patterns` | none | existing | Fully specced, MVP |
+| **2 — Nice-to-have** | `get_workout_analytics`, `get_event_readiness`, `detect_travel_impact`, `generate_report` | report writes file (opt-in path) | existing | Specced; ship if Tier 1 lands cleanly |
+| **3 — Reconcile** | `correlate_metrics` (generalizes the planned `get_correlations`) | none | existing | Specced; resolves D-1 overlap |
+| **4 — Gated** | `log_behavior` + WHOOP journal CSV import & correlation | **new** local store (0600) | existing | Specced but **deferred** — needs security pass + human sign-off |
+
+> **OPEN DECISION D-2:** Confirm Tier 1+2+3 ship in this release and Tier 4 is deferred to a follow-up (e.g. 0.6.1 or 0.7.0) pending a dedicated security audit of local behavior storage.
+
+---
+
+## Shared Foundations
+
+### `stats-utils.ts` extensions (pure TypeScript, no deps)
+
+Reuse existing `mean`, `median`, `standardDeviation`, `linearRegression`, `detectAnomalies`, `trendDirection`. Add:
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `percentile` | `(values: number[], p: number) => number` | **Linear-interpolation** percentile (p ∈ [0,100]); empty array throws; p0 = min, p100 = max; single element returns that element. |
+| `zScore` | `(value: number, mean: number, sd: number) => number` | Standardized deviation; returns 0 when sd === 0. |
+| `rollingWindow` | `(values: number[], size: number) => number[][]` | Yields full rolling windows of length `size`; when `values.length < size` returns `[]` (no partial windows); `size < 1` throws. |
+| `pearsonR` | `(x: number[], y: number[]) => number` | Correlation coefficient (already specced for v0.6.0; lands here under Option A). |
+| `isSignificant` | `(r: number, n: number) => boolean` | `R_CRITICAL_TABLE` lookup, floor-to-nearest-key (conservative). |
+| `correlationStrength` / `correlationDirection` | `(r) => ...` | Strength/direction classification. |
+
+All functions: empty array throws; `sd === 0` returns a defined value (no NaN propagation), consistent with existing module behavior.
+
+### Output-size / privacy convention (security M-2)
+
+Every tool result (including full `data_points` arrays and report bodies) is sent to the
+LLM provider by the nature of MCP. To minimize routine health-PII exposure: cap
+`data_points` arrays at a documented default length (the analysis stats are computed on
+the full set; only the echoed array is capped) and keep report/summary bodies
+summary-first. This is inherent to MCP, not new egress — but the new tools materially
+increase volume, so caps are required, not optional.
+
+### Baseline computation convention (shared by anomaly/baseline/training-load)
+
+```
+- Baseline window: rolling N days (default 30) of SCORED records only.
+- "Today" / "current" / "latest" value is EXCLUDED from the baseline/distribution it
+  is compared against (no self-contamination): baseline = records in [now - N days, today),
+  current = today. `get_baselines.latest_percentile` ranks `latest` against the window
+  EXCLUDING `latest` itself, consistent with this convention.
+- Records with score_state != "SCORED" are excluded from all stats.
+- Minimum data guard: each tool declares its minimum N of valid points; below that
+  it returns a clear "insufficient data to establish a baseline" message, never NaN.
+```
+
+### Pagination convention (shared) — avoid silent truncation
+
+`fetchAllPages` defaults to `maxRecords: 100`. Tools allowing windows up to 90–180 days
+(and sleep can yield multiple records/day via naps) can exceed 100 records and be
+**silently truncated**. Therefore:
+
+```
+- Each tool MUST pass an explicit maxRecords sized to its window, capped at the
+  module's ABSOLUTE_MAX_RECORDS = 500.
+- If a fetch hits the cap, the tool sets `truncated: true` in its output and the
+  summary notes that results are based on a partial window. Never report a
+  baseline/aggregate from a silently truncated set as if complete.
+```
+
+### Cross-source day-key convention (shared by correlate_metrics / day-of-week)
+
+Recovery and cycle records are cycle-keyed; sleep is wake-day-keyed. To align metrics
+from different endpoints on a common day index, all tools use the **`get_calendar`
+wake-day convention**: a record is assigned to the local calendar day of its relevant
+timestamp (sleep → `end`/wake-up day; recovery/cycle → cycle `start` local day),
+computed via each record's `timezone_offset`.
+
+### Disclaimer convention
+
+Every Tier 1–4 tool that produces an interpretation includes the single canonical
+string (identical to the v3 `get_correlations` design — one string, asserted by a
+shared test across all tools):
+
+```
+disclaimer: "Statistical observation from your data, not medical advice."
+```
+
+---
+
+## Tier 1 — Core Tools
+
+### Tool 1.1 — `detect_anomalies` (illness early-warning)
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `detect_anomalies` |
+| **Description** | Compare today's HRV, resting heart rate, and respiratory rate against your personal rolling baseline and flag deviations that may signal illness, overtraining, or stress. |
+| **Endpoints** | `/v2/recovery`, `/v2/activity/sleep` (respiratory rate lives on sleep score) |
+| **Scopes** | existing (`read:recovery read:sleep`) |
+
+**Input schema**
+```typescript
+z.object({
+  baseline_days: z.number().int().min(7).max(90).optional()
+    .describe("Rolling baseline window in days. Default: 30."),
+  threshold_sd: z.number().min(1).max(4).optional()
+    .describe("Std-deviation threshold to flag an anomaly. Default: 2."),
+})
+```
+
+**Output shape**
+```typescript
+interface AnomalyReport {
+  evaluated_at: string;            // ISO 8601
+  baseline_days: number;
+  threshold_sd: number;
+  metrics: AnomalyMetric[];
+  flagged: boolean;                // true if ANY metric breaches threshold
+  summary: string;                 // e.g. "Respiratory rate +2.3σ above baseline — possible early illness signal"
+  disclaimer: string;
+}
+interface AnomalyMetric {
+  metric: "hrv" | "rhr" | "respiratory_rate";
+  current: number | null;          // null if no scored value today
+  baseline_mean: number | null;
+  baseline_sd: number | null;
+  z_score: number | null;
+  direction: "above" | "below" | "normal";
+  flagged: boolean;                // |z| > threshold_sd
+  // Direction-aware note: elevated RHR/resp-rate or depressed HRV are the
+  // illness-suggestive directions; the note reflects this.
+  note: string;
+}
+```
+
+**Algorithm**
+1. Fetch baseline-window records (recovery + sleep), SCORED only, excluding today.
+2. Compute `mean`/`sd` per metric. HRV & RHR from recovery; respiratory rate from sleep.
+3. Today's values from the latest SCORED record(s).
+4. `z = zScore(current, mean, sd)`. Flag when `|z| > threshold_sd`.
+5. Direction-aware `note`: RHR↑ / resp-rate↑ / HRV↓ are illness-suggestive; the summary highlights the WHOOP-community-favored respiratory-rate signal first.
+
+**Acceptance criteria**
+- [ ] Flags HRV / RHR / respiratory-rate deviations beyond `threshold_sd` (default 2σ).
+- [ ] Today's value excluded from its own baseline.
+- [ ] Respiratory rate sourced from the most recent SCORED sleep; HRV/RHR from most recent SCORED recovery.
+- [ ] Each metric reports `direction` and a direction-aware illness-suggestive `note`.
+- [ ] `flagged` (top-level) true iff any metric breaches threshold.
+- [ ] Fewer than 7 valid baseline points → "insufficient data" message, no NaN.
+- [ ] `sd === 0` (constant baseline) → `z_score` 0, `direction` "normal", not flagged.
+- [ ] Missing today value (no SCORED record yet) → `current: null`, metric not flagged, summary notes the gap.
+- [ ] `disclaimer` present.
+- [ ] Unit tests: flagged-up, flagged-down, normal, missing-today, constant-baseline, insufficient-data.
+
+---
+
+### Tool 1.2 — `get_baselines` (personal normal ranges)
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_baselines` |
+| **Description** | Return your personal rolling baseline and percentile bands for HRV, resting heart rate, respiratory rate, sleep duration, and recovery score — so "is this normal for me?" can be answered against your own history. |
+| **Endpoints** | `/v2/recovery`, `/v2/activity/sleep` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  baseline_days: z.number().int().min(14).max(180).optional()
+    .describe("Rolling baseline window in days. Default: 30."),
+})
+```
+
+**Output shape**
+```typescript
+interface BaselineReport {
+  period: { start: string; end: string; days: number };
+  metrics: Record<BaselineMetricName, BaselineBand | null>; // null when insufficient data
+  disclaimer: string;
+}
+type BaselineMetricName = "hrv" | "rhr" | "respiratory_rate" | "sleep_hours" | "recovery_score";
+interface BaselineBand {
+  sample_size: number;
+  mean: number;
+  median: number;
+  std_dev: number;
+  p10: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p90: number;
+  latest: number | null;            // most recent SCORED value
+  latest_percentile: number | null; // where `latest` falls in the distribution (0–100)
+}
+```
+
+**Acceptance criteria**
+- [ ] Returns mean/median/sd + p10/p25/p50/p75/p90 per metric.
+- [ ] `latest_percentile` ranks `latest` against the window EXCLUDING `latest` itself (consistent with the baseline self-exclusion convention).
+- [ ] Metrics with < 14 valid points → `null` band (not partial/NaN).
+- [ ] `period.start`/`end` reflect the actual data range used.
+- [ ] `disclaimer` present.
+- [ ] Unit tests: full bands, single-metric-insufficient, all-insufficient, latest-at-extremes (p≈0 / p≈100).
+
+---
+
+### Tool 1.3 — `get_sleep_debt`
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_sleep_debt` |
+| **Description** | Compute cumulative sleep debt (needed vs. achieved) and bedtime/wake-time consistency, including weekday-vs-weekend "social jetlag", over a date range. |
+| **Endpoints** | `/v2/activity/sleep` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  days: z.number().int().min(3).max(90).optional()
+    .describe("Days to analyze. Default: 14."),
+  start: z.string().optional()
+    .describe("Start date — ISO 8601 or relative ('last 14 days', 'this month')."),
+})
+```
+
+**Output shape**
+```typescript
+interface SleepDebtReport {
+  period: { start: string; end: string; days: number };
+  nights_analyzed: number;
+  total_debt_hours: number;          // sum of max(0, needed - achieved) across nights
+  avg_nightly_debt_hours: number;
+  consistency: {
+    bedtime_std_dev_minutes: number; // variance of sleep-onset clock time
+    waketime_std_dev_minutes: number;
+    social_jetlag_minutes: number;   // |mean weekend midpoint - mean weekday midpoint|
+  };
+  nights: SleepDebtNight[];
+  summary: string;
+  disclaimer: string;
+}
+interface SleepDebtNight {
+  date: string;                      // wake-up day (YYYY-MM-DD)
+  needed_hours: number;              // sleep_needed total (baseline + debt + strain + nap)
+  achieved_hours: number;            // asleep time (in-bed minus awake)
+  debt_hours: number;                // max(0, needed - achieved)
+}
+```
+
+**Algorithm notes (pinned definitions — no hedging)**
+- **`needed_hours` = `baseline_milli + need_from_recent_strain_milli + need_from_recent_nap_milli`** (milli → hours). It **EXCLUDES `need_from_sleep_debt_milli`**. *Critical:* `need_from_sleep_debt_milli` is WHOOP's own running accumulation of prior nights' debt; including it and then re-summing `max(0, needed − achieved)` across the range would double-count and inflate `total_debt_hours` super-linearly. (See finding C1.) Note: `need_from_recent_nap_milli` is typically **negative** in the API (a recent nap *reduces* the night's need) — summing the fields handles this correctly; do NOT clamp, abs, or negate it.
+- **`achieved_hours` = sum of scored asleep stages = `total_light_sleep_time_milli + total_slow_wave_sleep_time_milli + total_rem_sleep_time_milli`** (milli → hours). This is the chosen, single definition — cleaner than in-bed-minus-awake — and deliberately excludes awake and `total_no_data_time_milli`.
+- Exclude `nap: true` records from nightly debt; the main night is the **longest non-nap SCORED sleep per wake-up day**.
+- Clock time uses each record's `timezone_offset` so bedtime consistency reflects local time, not UTC.
+- **Social jetlag (heuristic, not the clinical MSFsc):** absolute difference between mean sleep-midpoint on weekend nights (Sat/Sun wake-up) vs. weekday nights. Labeled a simplification in the summary.
+- If only weekday OR only weekend nights exist, `social_jetlag_minutes` is `null` (cannot compute a cross-group difference).
+
+**Acceptance criteria**
+- [ ] `needed_hours` excludes `need_from_sleep_debt_milli` (uses baseline + strain + nap only); a fixture proves a multi-night range does NOT super-accumulate debt.
+- [ ] `need_from_recent_nap_milli` is summed as-is (it is **negative** — a nap reduces need); a fixture with a nap-reduced-need night proves the negative value is preserved, not "fixed".
+- [ ] `achieved_hours` = light + slow-wave + REM stage sums (awake and no-data excluded).
+- [ ] `debt_hours` per night = `max(0, needed - achieved)` (never negative).
+- [ ] Naps (`nap: true`) excluded from nightly debt computation; a fixture with a nap on a night proves exclusion.
+- [ ] Bedtime/wake-time consistency computed in *local* time via `timezone_offset`.
+- [ ] `social_jetlag_minutes` = |weekend midpoint − weekday midpoint|; `null` when only one group present.
+- [ ] Nights without a SCORED main sleep are omitted from `nights` (and don't count toward `nights_analyzed`).
+- [ ] < 3 valid nights → "insufficient data" message.
+- [ ] Sleep crossing midnight assigned to wake-up day (consistent with `get_calendar`).
+- [ ] `truncated` flag honored per the pagination convention.
+- [ ] `disclaimer` present (canonical string).
+- [ ] Unit tests: positive debt, zero debt (over-slept), nap exclusion, DST spring-forward (23h) and fall-back (25h) boundaries with a fixed reference offset, weekend-only data (`social_jetlag_minutes: null`).
+
+---
+
+### Tool 1.4 — `get_training_load`
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_training_load` |
+| **Description** | Compute acute:chronic workload ratio (7-day vs 28-day strain), training monotony, and flag sustained high-strain + low-recovery streaks — the established overtraining-risk signals. |
+| **Endpoints** | `/v2/cycle` (daily strain), `/v2/recovery` (recovery for streak flagging) |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  end: z.string().optional().describe("End date — ISO 8601 or relative. Default: now."),
+  load_basis: z.enum(["strain", "kilojoule"]).optional()
+    .describe("Load metric for ACWR. Default: 'strain' (0–21, nonlinear — heuristic). 'kilojoule' is a linear, energy-based alternative."),
+})
+// Coupled ACWR: acute = trailing 7 days; chronic = trailing 28 days (which INCLUDES the acute 7).
+```
+
+**Output shape**
+```typescript
+interface TrainingLoadReport {
+  period: { start: string; end: string; days: number };
+  load_basis: "strain" | "kilojoule";
+  acute_load: number;                // mean daily load, trailing 7 days
+  chronic_load: number;              // mean daily load, trailing 28 days (COUPLED — includes the acute 7)
+  acwr: number | null;               // acute:chronic ratio; null when chronic data insufficient
+  acwr_zone: "undertraining" | "optimal" | "elevated" | "high_risk" | "insufficient_data";
+  provisional: boolean;              // true when < 21 of 28 chronic days are SCORED (ratio unreliable)
+  monotony: number | null;           // mean daily load / sd of daily load (7-day); null when sd===0
+  strain_streak: { length_days: number; threshold: number } | null; // consecutive high-strain days
+  low_recovery_high_strain_days: number; // count in window of (recovery<34 AND strain>14)
+  load_note: string;                 // states coupled-ACWR + strain-nonlinearity caveats
+  summary: string;
+  disclaimer: string;
+}
+```
+
+**Algorithm notes**
+- Daily load = the SCORED per-day value for the chosen `load_basis`: cycle `strain` (default) or cycle `kilojoule`.
+- **Coupled ACWR:** `acute_load` = mean daily load over trailing 7 days; `chronic_load` = mean daily load over trailing 28 days, which **includes** the acute 7 (the standard 7:28 coupled ratio). The literature distinguishes *coupled* (acute ⊆ chronic) from *uncoupled* (non-overlapping) ACWR — this tool uses **coupled** and says so in `load_note`.
+- **Strain is nonlinear:** WHOOP strain is a 0–21 *logarithmic* scale, so averaging it and ratio-ing the averages is a rougher heuristic than ACWR computed on linear load (sRPE/TRIMP/kilojoule). `kilojoule` is offered as a linear-energy alternative basis. `load_note` always states this caveat.
+- ACWR = `acute_load / chronic_load`.
+- **Insufficient chronic data:** if fewer than 21 of the 28 chronic-window days have a SCORED value (or `chronic_load === 0`), set `acwr: null`, `acwr_zone: "insufficient_data"`, and `provisional: true`. This is NOT "undertraining" — a brand-new user who just trained hard has high acute load and no chronic history; the summary says chronic history is too short for a reliable ratio.
+- **`provisional`** is `true` whenever < 21 of 28 chronic days are present; any ratio shown should be read cautiously.
+- ACWR zones (sports-science heuristic, applied only when not provisional): `< 0.8` undertraining, `0.8–1.3` optimal, `1.3–1.5` elevated, `> 1.5` high_risk.
+- **Monotony** = mean / sd of the 7-day load series. Constant load (`sd === 0`) is *maximum* monotony (the unhealthy case), NOT zero — so return `null` with a "no day-to-day variation" note rather than `0` (which would misleadingly read as healthy variety). (See finding I2.)
+- Streak = longest run of consecutive days with strain above a documented threshold (default 14).
+
+**Acceptance criteria**
+- [ ] `acute_load` = mean daily load over trailing 7 days; `chronic_load` over trailing 28 days (COUPLED — includes the acute 7), documented as coupled in `load_note`.
+- [ ] `load_basis` selects `strain` (default) or `kilojoule`; both computed from SCORED cycles.
+- [ ] `load_note` always present, stating both the coupled-ACWR choice and strain's 0–21 nonlinearity (heuristic).
+- [ ] `acwr` = acute/chronic when chronic data sufficient; `null` otherwise.
+- [ ] Insufficient chronic data (< 21 of 28 SCORED days OR `chronic_load === 0`) → `acwr: null`, `acwr_zone: "insufficient_data"`, `provisional: true` (NOT "undertraining").
+- [ ] `provisional` is `true` when < 21 of 28 chronic days present.
+- [ ] `acwr_zone` mapped per documented thresholds only when not provisional.
+- [ ] `monotony` = mean/sd of 7-day load; `sd === 0` → `null` (not 0) with explanatory note.
+- [ ] `low_recovery_high_strain_days` counts days meeting BOTH conditions.
+- [ ] < 7 valid acute load days → "insufficient data".
+- [ ] Missing days (no SCORED cycle) excluded from means; counts use available data, documented.
+- [ ] `truncated` flag honored per the pagination convention.
+- [ ] `disclaimer` present (overtraining heuristics are not medical advice).
+- [ ] Unit tests: optimal/elevated/high-risk zones, brand-new-user-trained-hard (chronic insufficient → `acwr: null`, `acwr_zone: "insufficient_data"`, `provisional: true`, NOT undertraining), provisional (< 21 chronic days), constant load (`monotony: null`), `kilojoule` basis, streak detection, combined-flag counting.
+
+---
+
+### Tool 1.5 — `get_day_of_week_patterns`
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_day_of_week_patterns` |
+| **Description** | Break down recovery, sleep, and strain by day of week to surface patterns like "Monday recovery is consistently lower" or weekday-vs-weekend differences. |
+| **Endpoints** | `/v2/recovery`, `/v2/activity/sleep`, `/v2/cycle` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  days: z.number().int().min(14).max(180).optional().describe("Lookback window. Default: 56 (8 weeks)."),
+})
+```
+
+**Output shape**
+```typescript
+interface DayOfWeekReport {
+  period: { start: string; end: string; days: number };
+  by_day: Record<Weekday, DayAggregate>;     // Mon..Sun
+  weekday_vs_weekend: {
+    recovery_delta: number | null;           // weekend mean - weekday mean
+    sleep_hours_delta: number | null;
+    strain_delta: number | null;
+  };
+  highlights: string[];                        // e.g. "Lowest avg recovery: Monday (54%)"
+  disclaimer: string;
+}
+interface DayAggregate {
+  sample_size: number;
+  avg_recovery: number | null;
+  avg_sleep_hours: number | null;
+  avg_strain: number | null;
+}
+```
+
+**Acceptance criteria**
+- [ ] Each weekday aggregates only SCORED records assigned to that local weekday (uses `timezone_offset`).
+- [ ] Days with no data → `null` averages, `sample_size: 0`.
+- [ ] `weekday_vs_weekend` deltas computed from non-null aggregates only.
+- [ ] `highlights` names the lowest/highest recovery weekday and any notable weekend gap.
+- [ ] < 14 days window → "insufficient data".
+- [ ] `disclaimer` present.
+- [ ] Unit tests: full week coverage, single-weekday-missing, weekend-vs-weekday delta sign.
+
+---
+
+## Tier 2 — Nice-to-Have Tools
+
+### Tool 2.1 — `get_workout_analytics`
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_workout_analytics` |
+| **Description** | Analyze workouts over a range — HR-zone distribution, strain-per-minute efficiency, best/worst sessions by activity type, and time-of-day effects. |
+| **Endpoints** | `/v2/activity/workout` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  days: z.number().int().min(7).max(180).optional().describe("Lookback window. Default: 30."),
+  sport: z.string().optional().describe("Filter by sport_name (case-insensitive)."),
+})
+```
+
+**Output (summary)**
+- Aggregate zone-duration distribution (% time in zones 0–5) from `zone_durations`.
+- `strain_per_minute` = strain / active minutes; best/worst sessions by this metric.
+- Per-`sport_name` rollups (count, avg strain, avg duration).
+- Time-of-day buckets (morning/afternoon/evening, local time via `timezone_offset`) with avg strain.
+
+**Acceptance criteria**
+- [ ] Zone distribution sums to ~100% (rounding documented).
+- [ ] `strain_per_minute` guards zero-duration workouts (excluded, documented).
+- [ ] `sport` filter case-insensitive; unknown sport → empty result with message.
+- [ ] Time-of-day buckets use local time.
+- [ ] < 1 SCORED workout in range → "insufficient data".
+- [ ] `disclaimer` present.
+- [ ] Unit tests: zone math, per-sport rollup, time-of-day bucketing, zero-duration guard.
+
+---
+
+### Tool 2.2 — `get_event_readiness`
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_event_readiness` |
+| **Description** | Given a target event date, project readiness from the recent recovery trend and suggest a taper window. |
+| **Endpoints** | `/v2/recovery`, `/v2/cycle` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  event_date: z.string()
+    .describe("Event date — ISO 8601 (YYYY-MM-DD) only. Must be today or in the future."),
+  lookback_days: z.number().int().min(14).max(90).optional().describe("Recovery-trend window. Default: 28."),
+})
+```
+
+> **Note:** `date-utils.resolveDateExpression` is backward-looking only (no "in 10 days"/"next Saturday"). Rather than add forward expressions (scope creep), `event_date` accepts an explicit ISO-8601 date only and is validated as today-or-future. (See finding I3.)
+
+**Output (summary)**
+- Recent recovery trend (slope/direction/confidence via existing `linearRegression` + `trendDirection`).
+- `days_until_event` (rejects past dates at the schema/handler boundary).
+- Projected readiness band (current baseline ± trend), **clamped to 0–100**, explicitly labeled a heuristic projection, not a prediction.
+- Suggested taper window (e.g. reduce strain N days out) framed as general guidance.
+
+**Acceptance criteria**
+- [ ] `event_date` is ISO-8601 only; past dates → validation error; relative expressions rejected with a clear message.
+- [ ] `days_until_event` correct (UTC day math).
+- [ ] Trend reuses existing regression utilities.
+- [ ] Projected readiness clamped to [0, 100] (no >100 or <0 from linear extrapolation).
+- [ ] Projection clearly labeled heuristic, not medical/performance guarantee.
+- [ ] < 14 valid recovery points → "insufficient data".
+- [ ] `disclaimer` present.
+- [ ] Unit tests: future event, today, past event rejected, relative-expression rejected, improving/declining/stable trend, extrapolation clamped at bounds, insufficient data.
+
+---
+
+### Tool 2.3 — `detect_travel_impact`
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `detect_travel_impact` |
+| **Description** | Detect timezone shifts from cycle/sleep records and quantify how many days recovery takes to rebound after travel (jet-lag recovery). |
+| **Endpoints** | `/v2/cycle`, `/v2/recovery` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  days: z.number().int().min(14).max(180).optional().describe("Lookback window. Default: 60."),
+  min_offset_change_hours: z.number().int().min(1).max(12).optional()
+    .describe("Minimum timezone-offset change (hours) to count as travel. Default: 2."),
+})
+```
+
+**Output (summary)**
+- Detected travel events: date, offset change (hours), direction (east/west).
+- Per-event recovery rebound: days until recovery returns to within the rebound band of the pre-travel baseline mean. **Rebound band = ±0.5σ of the pre-travel recovery baseline** (module constant `REBOUND_BAND_SD = 0.5`).
+- Aggregate avg rebound days.
+
+**Acceptance criteria**
+- [ ] Travel event detected when consecutive-record `timezone_offset` change ≥ `min_offset_change_hours`.
+- [ ] Offset parsed from WHOOP's `+HH:MM` / `-HH:MM` string format.
+- [ ] Rebound = days for recovery to return within ±0.5σ (`REBOUND_BAND_SD = 0.5`) of the pre-travel recovery baseline mean; capped (and flagged) if it never recovers within the window.
+- [ ] No travel events → empty list with clear message.
+- [ ] < 14 days → "insufficient data".
+- [ ] `disclaimer` present.
+- [ ] Unit tests: eastward/westward detection, sub-threshold ignored, rebound counting at the ±0.5σ band, never-rebounds-in-window (capped + flagged), no-travel case, offset-string parsing.
+
+---
+
+### Tool 2.4 — `generate_report`
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `generate_report` |
+| **Description** | Export a date range of WHOOP data as Markdown or CSV — addresses the long-standing data-export frustration. |
+| **Endpoints** | `/v2/recovery`, `/v2/activity/sleep`, `/v2/cycle`, `/v2/activity/workout` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  format: z.enum(["markdown", "csv"]).describe("Output format."),
+  days: z.number().int().min(1).max(180).optional().describe("Lookback window. Default: 30."),
+  start: z.string().optional().describe("Start date — ISO 8601 or relative."),
+  sections: z.array(z.enum(["recovery", "sleep", "strain", "workouts"])).optional()
+    .describe("Which sections to include. Default: all."),
+})
+```
+
+**Output / behavior**
+- Returns the report content **inline as a string** in the tool result (the primary, safe path — the assistant presents/saves it).
+- File-write to disk is **NOT** done by default. (Writing arbitrary paths from an MCP tool is a security surface — path traversal.) If a future `output_path` option is added, it MUST be confined to a configurable safe directory with traversal rejection. Flagged as OPEN DECISION D-3.
+- **CSV formula-injection neutralization (security C-1):** RFC-4180 quoting alone does NOT prevent spreadsheet formula execution. Any cell whose first character is in the set `= + - @ \t \r` (tab `0x09`, CR `0x0D`) is neutralized by prefixing a single quote (`'`) BEFORE RFC-4180 quoting. This applies to the **inline string path too** (users paste reports into Excel/Sheets), and shares the exact same neutralizer code path as the Tier-4 CSV import (so any imported value re-exported here is also neutralized).
+
+**Acceptance criteria**
+- [ ] Markdown output is valid, with section headers and tables.
+- [ ] CSV output is RFC-4180-safe (quote/escape fields containing commas, quotes, newlines).
+- [ ] CSV cells leading with `= + - @ \t \r` are neutralized (prefixed `'`) — including a fixture for a legitimately negative value (e.g. `-5` HRV delta) proving real data isn't corrupted, only made inert.
+- [ ] `sections` filter respected; default all.
+- [ ] Returns content inline (no implicit disk write).
+- [ ] Empty range → report with "no data" notices, not an error.
+- [ ] `disclaimer` line included in the report body.
+- [ ] Unit tests: markdown structure, CSV escaping (comma/quote/newline), formula-injection neutralization (`=`,`+`,`-`,`@`,`\t`,`\r` leads + negative-number non-corruption), section filtering, empty range.
+
+> **OPEN DECISION D-3:** Should `generate_report` ever write to disk? Default spec: no (inline string only). If yes, requires a sandboxed output directory + path-traversal rejection + a security review.
+
+---
+
+## Tier 3 — `correlate_metrics` (reconciles planned `get_correlations`)
+
+Generalizes the v0.6.0 `get_correlations` design (preset correlation types) into an **arbitrary-pair, lagged** correlation tool. Under Option A, this *replaces* `get_correlations` (one tool, not two).
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `correlate_metrics` |
+| **Description** | Compute the correlation between any two daily health metrics, with an optional day lag — e.g. day-N strain vs. day-(N+1) recovery, or sleep duration vs. next-day HRV. |
+| **Endpoints** | `/v2/recovery`, `/v2/activity/sleep`, `/v2/cycle` |
+| **Scopes** | existing |
+
+**Input schema**
+```typescript
+z.object({
+  // EITHER a named preset (reproduces the legacy get_correlations types verbatim)
+  preset: z.enum([
+    "sleep_duration_vs_recovery",
+    "strain_vs_next_day_recovery",
+    "hrv_vs_sleep_performance",
+    "workout_strain_vs_recovery_drop",
+    "sleep_consistency_vs_hrv",
+  ]).optional().describe("Named correlation preset. Mutually exclusive with x_metric/y_metric."),
+  // OR an arbitrary daily-metric pair with optional lag
+  x_metric: z.enum(["recovery", "hrv", "rhr", "respiratory_rate",
+                    "sleep_hours", "sleep_performance", "strain"]).optional(),
+  y_metric: z.enum(["recovery", "hrv", "rhr", "respiratory_rate",
+                    "sleep_hours", "sleep_performance", "strain"]).optional(),
+  lag_days: z.number().int().min(0).max(7).optional()
+    .describe("Days y trails x. 0 = same day. Default: 0. (e.g. x=strain, y=recovery, lag=1)."),
+  days: z.number().int().min(14).max(90).optional().describe("Lookback window. Default: 30."),
+})
+// Zod .refine(): exactly one of { preset } or { x_metric AND y_metric } must be supplied.
+// preset "sleep_consistency_vs_hrv" enforces days >= 21 (7-day window warmup + 14 pairs).
+```
+
+> **Resolving the preset gap (C2/D-4):** Two legacy correlations are NOT plain scalar-pair-with-lag and cannot be expressed by `x_metric`/`y_metric` alone:
+> - `sleep_consistency_vs_hrv` — X is a *rolling 7-day std-dev of bedtime* (a derived windowed series).
+> - `workout_strain_vs_recovery_drop` — Y is a *recovery delta* (day-before → day-after a workout), keyed on workouts not days.
+>
+> These are therefore kept as **named presets** with their original derived-series logic, so `correlate_metrics` fully supersedes `get_correlations` with no regression. The generic `x_metric`/`y_metric`/`lag_days` path covers the other three presets and any new arbitrary pair.
+
+**Output shape** (mirrors the existing `CorrelationResult` design)
+```typescript
+interface CorrelationResult {
+  preset: string | null;         // named preset, or null for arbitrary pair
+  x_metric: string;
+  y_metric: string;
+  lag_days: number;
+  period: { start: string; end: string; days: number };
+  sample_size: number;           // paired points after lag alignment
+  pearson_r: number;
+  strength: "strong" | "moderate" | "weak" | "none";
+  direction: "positive" | "negative" | "none";
+  p_significant: boolean;        // R_CRITICAL_TABLE lookup
+  insight: string;               // grammatical, with specific numbers
+  recommendation: string;        // actionable, health-appropriate
+  data_points: Array<{ date: string; x_value: number; y_value: number }>; // capped (see M2)
+  disclaimer: string;            // always present (canonical string)
+}
+```
+
+**Acceptance criteria**
+- [ ] Zod `.refine()`: rejects supplying both `preset` and `x_metric`/`y_metric`, and rejects a lone `x_metric` without `y_metric`.
+- [ ] Day alignment uses the shared cross-source wake-day convention; pairs x[day N] with y[day N + lag_days]; misaligned/missing days excluded.
+- [ ] Reuses `pearsonR`, `correlationStrength`, `correlationDirection`, `isSignificant`.
+- [ ] `x_metric === y_metric && lag_days === 0` → validation error (trivial self-correlation).
+- [ ] Zero-variance series → r 0, strength "none" (no NaN/throw).
+- [ ] < 7 valid paired points → "Insufficient paired data" error.
+- [ ] `p_significant` from `R_CRITICAL_TABLE` (floor-to-nearest-key).
+- [ ] **All five legacy presets reproducible** — the three scalar presets via param combos AND the two derived presets (`sleep_consistency_vs_hrv`, `workout_strain_vs_recovery_drop`) via the named-preset path (back-compat coverage, no regression vs. `get_correlations`).
+- [ ] `sleep_consistency_vs_hrv` preset enforces `days >= 21`.
+- [ ] `data_points` capped per M2 (default cap, documented).
+- [ ] `disclaimer` always present.
+- [ ] Unit tests: perfect +/- correlation, lag alignment (sign/magnitude change), missing-day exclusion, self-correlation rejection, preset/pair mutual-exclusion, zero-variance, significance just-above/just-below threshold, each of the 5 presets.
+
+> **OPEN DECISION D-4:** Confirm `correlate_metrics` supersedes the planned `get_correlations` (Option A). If `get_correlations` already shipped or is mid-flight, decide deprecate-and-alias vs. keep-both.
+
+---
+
+## Tier 4 — GATED: `log_behavior` + WHOOP CSV journal correlation
+
+> **This tier introduces the project's first user-data persistence beyond OAuth tokens and a new untrusted-input surface (CSV upload). It is DEFERRED pending a dedicated security audit and explicit human sign-off (per the "Ask First" boundary: token storage changes / new persisted state).** The design below is the proposal to be reviewed, not approved scope.
+
+### 4.1 `log_behavior`
+
+Let users log behaviors (alcohol, caffeine, late meal, stress, etc.) that the WHOOP journal would capture but the v2 API does not expose. Stored locally, correlated against API data via `correlate_metrics`-style analysis.
+
+- **Storage:** `~/.whoop-mcp/behaviors.json`, file mode `0600`, in the `~/.whoop-mcp/` directory which must be `0700`. Same directory/permission model as tokens. Created with restrictive perms; never world-readable.
+- **Schema (per entry):** `{ id, date (YYYY-MM-DD), behavior (enum + freeform note), value?, created_at }`. `id` is a `crypto.randomUUID()` (not a counter). Validated with a `.strict()` Zod schema. Freeform note length-capped (≤ 500 chars) and stored as-is (no execution).
+- **Operations:** `add`, `list`, `delete` (by id), `clear`. `clear` (wipes all entries) is destructive and requires an explicit `confirm: true` input flag. No network egress of behavior data.
+- **Correlation:** join logged behaviors (binary present/absent or numeric value) per day against a chosen WHOOP metric (e.g. alcohol → next-day HRV) using the Tier-3 correlation engine. Freeform notes surfaced in output are rendered as quoted user data, never interpreted as instructions.
+
+**Security requirements (must pass audit):**
+- [ ] `~/.whoop-mcp/` directory created/asserted `0700`; `behaviors.json` created `0600`; perms re-asserted on every write.
+- [ ] Atomic writes: temp file created in the SAME directory via `fs.open(..., 'wx', 0o600)` (`O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW`), then `rename`. Never write to `/tmp`. Verify target is not a symlink (`O_NOFOLLOW`/`lstat`) to prevent TOCTOU/symlink redirection.
+- [ ] Store **re-validated with `.strict()` Zod on every load** (integrity boundary — file may be tampered/hand-edited). Invalid/corrupt files quarantined with a clear error, never a raw throw.
+- [ ] Prototype-pollution guard: drop `__proto__`/`constructor`/`prototype` keys; no object-merge of parsed data.
+- [ ] Path is fixed (`~/.whoop-mcp/`); no user-controlled path component.
+- [ ] Entry-count cap (e.g. ≤ 10k) and total-file-size cap (e.g. ≤ 5 MB) — clear error at the limit (disk-fill DoS guard).
+- [ ] Freeform notes never interpolated into shell/SQL/HTML; size-capped (≤ 500 chars); enforced at the Zod boundary.
+- [ ] `clear` requires `confirm: true`.
+- [ ] No behavior data sent to WHOOP or any network endpoint; a no-egress test proves it (and that it never appears in logs).
+
+### 4.2 WHOOP data-export CSV import
+
+Accept an uploaded WHOOP CSV export (which *does* include journal entries) and join it with live API data.
+
+> **Framing (where the formula-injection guard belongs):** CSV *formula* injection (`= + - @` …) is an **output/display** risk — a parser does not execute formula cells; the spreadsheet that later *opens* the file does. That guard therefore lives at the **`generate_report` CSV output** boundary (C-1), NOT in the import parser. The import parser treats every cell as inert data. Import's real risks are resource/DoS and malformed input — the requirements below check those.
+
+**Security requirements (must pass audit):**
+- [ ] Input is **in-memory string content only** — no filesystem path param (eliminates path-traversal/symlink class entirely; the assistant already has the content). If a path is ever added later, require `realpath` canonicalization, allowlisted base-dir confinement, `..` rejection, and symlink rejection (same review bar as D-3).
+- [ ] CSV parsed with a strict, dependency-free, **streaming/char-scan** parser (no `eval`; no whole-file regex — ReDoS guard). Cells are treated as opaque data; the parser does NOT interpret `= + - @` leads (formula neutralization is an output concern handled in `generate_report`, not here).
+- [ ] Caps: total content size, row count, **per-field length, and column count** all bounded (a single multi-GB cell or millions of columns is a memory DoS even within a row cap).
+- [ ] Reject NUL bytes; enforce UTF-8; reject compressed input.
+- [ ] Any imported value later re-emitted via `generate_report` is neutralized at THAT output boundary by the shared C-1 neutralizer (not at import time).
+- [ ] Malformed CSV → clear error, no partial corruption of any local store.
+- [ ] Imported data never re-uploaded to any network endpoint (no-egress test).
+
+> **OPEN DECISION D-5:** Defer Tier 4 entirely to a follow-up release gated on a security audit (recommended), or attempt it in-release. Recommended: **defer**.
+
+---
+
+## Project Structure (additions)
+
+```
+src/tools/
+  detect-anomalies.ts            # Tool 1.1
+  get-baselines.ts               # Tool 1.2
+  get-sleep-debt.ts              # Tool 1.3
+  get-training-load.ts           # Tool 1.4
+  get-day-of-week-patterns.ts    # Tool 1.5
+  get-workout-analytics.ts       # Tool 2.1
+  get-event-readiness.ts         # Tool 2.2
+  detect-travel-impact.ts        # Tool 2.3
+  generate-report.ts             # Tool 2.4
+  correlate-metrics.ts           # Tool 3 (supersedes get-correlations)
+  stats-utils.ts                 # MODIFY — add percentile, zScore, rollingWindow, pearsonR, isSignificant, ...
+  # Tier 4 (gated, deferred):
+  # log-behavior.ts
+  # behavior-store.ts
+tests/tools/                     # mirror each new file with *.test.ts
+src/server.ts                    # MODIFY — register new tools
+```
+
+One tool per file; Zod schema + handler co-located; named exports; explicit return types. Tool names `snake_case`, files `kebab-case.ts`, types `PascalCase`, functions `camelCase`.
+
+---
+
+## Code Style (matches existing tools)
+
+```typescript
+// src/tools/detect-anomalies.ts
+import { z } from "zod";
+import type { WhoopClient } from "../api/client.js";
+import { fetchAllPages } from "../api/pagination.js";
+import { ENDPOINT_RECOVERY, ENDPOINT_SLEEP } from "../api/endpoints.js";
+import { mean, standardDeviation, zScore } from "./stats-utils.js";
+
+export const detectAnomaliesSchema = {
+  name: "detect_anomalies",
+  description:
+    "Compare today's HRV, resting heart rate, and respiratory rate against your " +
+    "personal rolling baseline and flag deviations that may signal illness or overtraining.",
+  inputSchema: z.object({
+    baseline_days: z.number().int().min(7).max(90).optional()
+      .describe("Rolling baseline window in days. Default: 30."),
+    threshold_sd: z.number().min(1).max(4).optional()
+      .describe("Std-deviation threshold to flag an anomaly. Default: 2."),
+  }),
+};
+
+export async function detectAnomalies(
+  client: WhoopClient,
+  params: { baseline_days?: number; threshold_sd?: number }
+): Promise<AnomalyReport> {
+  // ... fetch baseline window, compute z-scores, flag deviations ...
+}
+```
+
+---
+
+## Testing Strategy
+
+- **TDD** — failing test first, then implement (Prove-It for any bug).
+- **Mock the WHOOP API** — `vi.fn()` over `globalThis.fetch`; never hit the real API.
+- **Deterministic time** — `vi.useFakeTimers()` with a FIXED system time for every tool touching "today"/relative ranges; timers restored in `afterEach` to prevent cross-test bleed. DST tests pin an explicit reference offset (spring-forward 23h day, fall-back 25h day).
+- **Stats unit tests** — hand-computed fixtures for `percentile`, `zScore`, `pearsonR`, `isSignificant`; each expected value annotated with its derivation (or cross-checked against a second method) so a future editor can't "fix" a test to match a buggy impl.
+- **Property tests:**
+  - `pearsonR`: perfect +correlation (y=2x+3 → r=1), perfect − (y=−x → r=−1), zero-variance → 0, symmetry `r(x,y)===r(y,x)`, bounded `−1≤r≤1`, scale/shift invariance `r(ax+b,y)===r(x,y)` for a>0, sign flip `r(−x,y)===−r(x,y)`.
+  - `percentile`: monotonic non-decreasing in p, `percentile(xs,0)===min`, `percentile(xs,100)===max`, single-element array, linear-interpolation midpoints.
+  - `rollingWindow`: output length = `max(0, n - size + 1)`; `n < size → []`; `size<1` throws.
+  - `isSignificant`: just-above / just-below threshold pair; `n < 7 → false`.
+- **Per-tool tests** — at minimum: happy path, insufficient-data, missing/PENDING records, constant/zero-variance, timezone/DST boundary (where local-time logic applies), and the `truncated` flag path where pagination caps apply.
+- **Shared disclaimer test** — one parametrized test asserts EVERY analytics tool's output carries the exact canonical disclaimer string (catches a new tool dropping it).
+- **Server integration** — one integration test asserts all ~10 new tools are registered on the MCP server with unique `snake_case` names and valid Zod input schemas (catches a tool implemented but never wired up).
+- **CSV safety (Tier 4 + generate_report)** — explicit fixtures for formula-leading cells (`=`,`+`,`-`,`@`,`\t`,`\r`), an embedded `","`/newline field, and a legitimately negative value proving non-corruption; Tier-4 import adds NUL-byte, oversized-cell, and column-bomb fixtures.
+- **Coverage targets** — > 80% on `src/auth/` and `src/api/` (unchanged); `stats-utils.ts` (core math) and new analytics tools held to the same > 80% bar; > 70% overall.
+- Run `npm test` after every increment; `npm run lint && npm run typecheck && npm run build` must be green before any commit.
+
+---
+
+## Boundaries
+
+**Always**
+- Validate all tool input with Zod; reject out-of-range windows at the schema layer.
+- Exclude non-SCORED records and the "current" value from its own baseline.
+- Return a clear "insufficient data" message (never NaN/throw) below each tool's minimum.
+- Attach the non-medical-advice `disclaimer` to every interpretive result.
+- Reuse `fetchAllPages`, `date-utils`, and `stats-utils` rather than re-implementing.
+- Run tests + lint + typecheck + build before committing.
+
+**Ask first**
+- Tier 4 (`log_behavior`, CSV import) — new persisted state + untrusted input (D-5).
+- `generate_report` writing to disk (D-3).
+- Any new runtime dependency (none anticipated).
+- Deprecating/aliasing the planned `get_correlations` (D-4).
+
+**Never**
+- Add new OAuth scopes (none needed).
+- Hit the real WHOOP API in tests.
+- Send any user/behavior data to a network endpoint other than WHOOP's read APIs.
+- Use `any`; commit secrets; remove or skip failing tests.
+- Present statistical output as medical advice.
+
+---
+
+## Success Criteria (verifiable)
+
+- [ ] **D-1 decided** (version label + correlations reconciliation) and reflected in `package.json` + `CHANGELOG.md`.
+- [ ] Tier 1 tools (`detect_anomalies`, `get_baselines`, `get_sleep_debt`, `get_training_load`, `get_day_of_week_patterns`) implemented, registered, and passing all acceptance criteria — verify: `npm test -- tests/tools/`.
+- [ ] Tier 2 tools implemented (or explicitly deferred with rationale).
+- [ ] `correlate_metrics` implemented; the five legacy preset correlations reproducible via params (D-4 resolved).
+- [ ] Tier 4 either shipped *after* a passing security audit, or formally deferred (D-5).
+- [ ] Every interpretive tool output includes the disclaimer — verify via a shared test asserting the field is present.
+- [ ] No new runtime dependencies in `package.json`.
+- [ ] No new OAuth scopes in the auth request.
+- [ ] `npm run lint && npm run typecheck && npm run build` clean; coverage thresholds met.
+- [ ] README + CHANGELOG updated; tool count updated (14 → 14 + N).
+
+---
+
+## Open Questions (consolidated)
+
+| ID | Question | Spec default |
+|----|----------|--------------|
+| D-1 | Ship as 0.6.0 (recommended) or force 0.5.3 label? | 0.6.0, Option A |
+| D-2 | Tier 1+2+3 in-release, Tier 4 deferred? | Yes |
+| D-3 | `generate_report` disk write? | No — inline string only |
+| D-4 | `correlate_metrics` supersedes `get_correlations`? | Yes (one tool) |
+| D-5 | Tier 4 (`log_behavior` + CSV) defer to follow-up? | Defer pending security audit |
+
+---
+
+## Sub-Agent Review Summary (incorporated 2026-06-11)
+
+The draft was reviewed by `code-reviewer`, `security-auditor`, and `test-engineer`. Material findings and their resolution:
+
+| Finding | Source | Resolution in this spec |
+|---------|--------|-------------------------|
+| **C1** — `get_sleep_debt` double-counts `need_from_sleep_debt_milli` | code-reviewer | `needed_hours` redefined to exclude the debt component (baseline + strain + nap only). |
+| **C2/D-4** — `correlate_metrics` can't reproduce 2 of 5 legacy presets | code-reviewer | Added a named-`preset` path alongside the generic pair path; both derived presets preserved. |
+| **C-1 (sec)** — `generate_report` CSV formula injection (non-gated) | security-auditor | Added formula-cell neutralization (`= + - @ \t \r`) shared with Tier-4 import, including inline path. |
+| **I1** — Coupled ACWR + log-scale strain | code-reviewer | **Human override (rev 2):** keep **coupled** ACWR (acute ⊆ chronic), documented as such in `load_note`; added `kilojoule` linear-load alternative + nonlinearity caveat. (Reviewer had suggested uncoupled.) |
+| **I2** — Monotony `sd===0 → 0` is inverted | code-reviewer | Returns `null` (not 0) for constant strain. |
+| **I3** — `get_event_readiness` forward dates don't exist; extrapolation unbounded | code-reviewer | ISO-8601-only `event_date` (today-or-future); readiness clamped to [0,100]. |
+| **I4** — Silent pagination truncation | code-reviewer | Added shared pagination convention: explicit `maxRecords` + `truncated` flag. |
+| **I5** — `get_sleep_debt` "achieved" under-specified | code-reviewer | Pinned to sum of light+SWS+REM stage sums. |
+| **I6** — Training-load chronic minimum too low | code-reviewer | Added `provisional` flag (rev 2) — requires ≥ 21 of 28 SCORED chronic days for a reliable ACWR; below that, `acwr: null` + `acwr_zone: "insufficient_data"`. |
+| **I-1..I-5 (sec)** — Tier-4 storage/CSV hardening | security-auditor | Temp-file `O_EXCL`/`O_NOFOLLOW`/`0600`, dir `0700`, count/size/field/column caps, Zod-on-load + prototype-pollution guard, in-memory-only CSV, ReDoS/NUL/UTF-8 guards. |
+| **M2/M3/M4 (sec)** — data_points cap, randomUUID + confirm-on-clear, note-as-data | security-auditor | Output-size convention added; `crypto.randomUUID()` ids; `clear` requires `confirm: true`; notes rendered as quoted data. |
+| **Test verifiability** — vague criteria, missing property/DST/registration tests, disclaimer test | test-engineer | Testing Strategy expanded: property tests, fixed fake-timers + DST, shared disclaimer test, server-registration test, fixture provenance, stats-utils held to >80%. |
+| **M1/M3/M4/M5** — social-jetlag label, day-key convention, latest_percentile note, canonical disclaimer | code-reviewer | Labeled social jetlag a heuristic; added cross-source day-key convention; documented `latest_percentile` self-inclusion; single canonical disclaimer string. |
+
+Deferred-by-design (confirmed sound by all three): Tier 4 gating (D-5), `generate_report` inline-only default (D-3), webhooks pushed to 0.7.0.
+
+---
+
+## Acceptance Definition
+
+This spec is "done" (ready for the Plan phase) when:
+1. The human has resolved D-1 through D-5.
+2. ✅ `code-reviewer`, `security-auditor`, and `test-engineer` sub-agents have reviewed and their findings are incorporated (see summary above).
+3. The human approves the final scope.

--- a/docs/specs/v5-coaching-personalization.md
+++ b/docs/specs/v5-coaching-personalization.md
@@ -1,0 +1,547 @@
+# Spec: WHOOP MCP Server — v0.6 Coaching & Personalization Layer
+
+> **Status:** Draft (awaiting human approval + sub-agent review)
+> **Target release:** `0.6.0` (the *user-facing coaching layer* of the 0.6.0 release — see [Versioning & Relationship to v4](#versioning--relationship-to-v4))
+> **Spec iteration:** v5 (follows `v4-personal-analytics.md`)
+> **Date:** 2026-06-13
+> **Baseline:** v0.5.x shipped — 14 tools, 4 resources, 5 prompts, ~700 tests, lint/typecheck/build clean
+> **Depends on:** `v4-personal-analytics.md` analytics primitives (`get_training_load`, `get_sleep_debt`, `get_baselines`, `detect_anomalies`)
+> **Source of requirements:** Top-10 r/whoop community asks, filtered to what a read-only WHOOP-OAuth MCP can *actually* solve.
+
+---
+
+## Objective
+
+The v4 analytics layer turns raw WHOOP records into **interpretations** (baselines, sleep debt, training load, anomalies). This v0.6 layer turns those interpretations into the **decisions and forward projections** users actually ask for:
+
+- *"I'm at 45% recovery — what should today's workout be?"* → `get_daily_recommendation`
+- *"What time should I sleep tonight (and the next few nights) to be green for Saturday's race?"* → `forecast_sleep`
+- *"Is a 7.2% HRV good for my age?"* → `get_benchmarks`
+- A coaching conversation that reasons over recovery + strain + sleep + anomalies at once → `daily_coaching` prompt.
+
+**Target users:** AI assistant users (Claude Desktop, Claude Code, claude.ai web, Cursor) who want their WHOOP data turned into *what to do next*, grounded in their own history.
+
+**Why this matters (the moat):** WHOOP Coach gives generic, single-metric answers. These tools let a stronger model reason over recovery, acute:chronic load, sleep debt, and anomaly signals **together**, personalized to the user's own baseline — fully within WHOOP's read-only OAuth API (TOS-compliant, zero ban risk).
+
+**Success looks like:**
+- An assistant can give a concrete training recommendation (push / maintain / recover + a target strain band) from one tool call that already accounts for recovery, recent load, sleep debt, and anomaly flags.
+- An assistant can project the nightly sleep needed over the coming nights to hit a target by a future date.
+- An assistant can place a user's HRV/RHR/sleep against published age/sex norms *with the right caveats*.
+- Every interpretive answer carries the canonical "not medical advice" disclaimer.
+
+---
+
+## Scope & Mapping to the Top-10 r/whoop Asks
+
+| # | r/whoop ask | This spec | Notes |
+|---|-------------|-----------|-------|
+| 5 | Daily training recommendations | ✅ `get_daily_recommendation` | Core deliverable |
+| 7 | Sleep planning & debt forecasting | ✅ `forecast_sleep` | Forward-looking complement to v4's backward `get_sleep_debt` |
+| 10 | Benchmarking & population context | ✅ `get_benchmarks` | Partner/friend comparison **out of scope** (single-user OAuth) |
+| 4 | Smarter WHOOP Coach | ✅ `daily_coaching` prompt | Orchestration over the new + existing tools |
+| 1 | Raw data export | — (v4 `generate_report`) | Already specced in v4 |
+| 2 | Long-term trends / custom ranges | — (shipped) | `get_trend`, `compare_periods` |
+| 3 | Behavior–recovery correlations | — (v4 `correlate_metrics`) | Already specced in v4 |
+| 6 | Custom weekly/monthly reports | — (v4 `generate_report`, `get_weekly_summary`) | Already covered |
+| 9 | Illness/overtraining early warning | 🔶 Detection in v4 `detect_anomalies`; **proactive push deferred** | Webhooks + scheduling → **0.7.0** (see [Deferred](#deferred--out-of-scope)) |
+| 8 | Cross-app integration (Strava/Calendar/etc.) | ❌ Non-goal | Multi-connector concern; belongs at the assistant level, not this server |
+
+---
+
+## Versioning & Relationship to v4
+
+Two specs now target `0.6.0`: this one and `v4-personal-analytics.md`. They are **complementary layers**, not competitors:
+
+- **v4 = analytics primitives** (compute baselines, sleep debt, training load, anomalies).
+- **v0.6 coaching layer (this spec) = composition over those primitives** into decisions/forecasts.
+
+These tools are thin orchestration over v4's outputs — `get_daily_recommendation` reuses `get_training_load` + `get_sleep_debt` + `detect_anomalies`; `forecast_sleep` reuses the sleep-need fields; `get_benchmarks` reuses `get_baselines`.
+
+| Option | Description | Tradeoff |
+|--------|-------------|----------|
+| **A (recommended)** | Ship v4 primitives **and** this coaching layer together as **0.6.0**. v4 lands first (prerequisite), this layer second, one release. | Delivers the actual user-facing value of 0.6.0; clean dependency order. |
+| **B** | Ship v4 as 0.6.0, this coaching layer as **0.6.1 / 0.7.0**. | Smaller releases; users wait for the headline "what should I do today" feature. |
+| **C** | Build coaching tools standalone (no v4 dependency), duplicating ACWR/sleep-debt math inline. | Code duplication; rejected. |
+
+**This spec assumes Option A and treats v4 Tier-1 tools as a hard prerequisite.**
+
+> **OPEN DECISION D-1:** Confirm Option A (bundle with v4 as 0.6.0) vs. Option B (follow-on point release). **This decision is conditional on v4's own D-1** (v4 recommends 0.6.0 but the human may force 0.5.3). If v4 ships as 0.5.3, this layer's version string follows suit (the tool designs are unchanged — only the release label differs).
+
+---
+
+## Assumptions
+
+```
+ASSUMPTIONS (verified against src/api/types.ts unless noted):
+1. v4-personal-analytics.md Tier-1 tools (get_training_load, get_sleep_debt,
+   get_baselines, detect_anomalies) and the stats-utils.ts extensions ship FIRST
+   and are importable. This spec depends on them. (NOT independently verifiable —
+   gated on v4 landing.)
+2. WHOOP v2 profile exposes NO age or date of birth. UserProfile = { user_id,
+   email, first_name, last_name } only; BodyMeasurement = { height_meter,
+   weight_kilogram, max_heart_rate }. THEREFORE get_benchmarks takes `age`/`sex`
+   as USER INPUT — they cannot be read from the API. (VERIFIED in types.ts.)
+3. Required score fields exist (VERIFIED):
+   - Recovery.score.recovery_score, hrv_rmssd_milli, resting_heart_rate
+   - Sleep.score.sleep_needed { baseline_milli, need_from_sleep_debt_milli,
+     need_from_recent_strain_milli, need_from_recent_nap_milli },
+     stage_summary, sleep_performance_percentage?, respiratory_rate?
+   - Cycle.score.strain, kilojoule
+4. No new OAuth scopes — existing six read: scopes cover all data.
+5. No new RUNTIME dependencies. Benchmarking norms are a BUNDLED static
+   TypeScript table (a data module checked into the repo), not a network call
+   or a new package.
+6. date-utils.resolveDateExpression is backward-looking only. forecast_sleep's
+   target_date therefore accepts an explicit ISO-8601 future date only (same
+   pattern as v4 get_event_readiness), NOT relative forward expressions.
+7. All computation stays in-process. No new persistent state, no untrusted input
+   surface (benchmarks read bundled constants; no file/CSV import here).
+8. Node.js >= 20 remains the minimum (unchanged).
+→ Correct these now or implementation proceeds with these.
+```
+
+---
+
+## Tech Stack (unchanged)
+
+- TypeScript ~5.x (strict, no `any`), Node.js >= 20, native `fetch`
+- `@modelcontextprotocol/sdk`, Zod — no other runtime deps
+- Vitest, ESLint, Prettier; build via `tsc`
+
+## Commands (unchanged)
+
+```bash
+npm run build        # tsc
+npm test             # vitest run
+npm test -- --coverage
+npm run lint
+npm run typecheck
+npm run dev
+```
+
+---
+
+## Shared Foundations (reused, not re-implemented)
+
+- **Pagination:** reuse `fetchAllPages` with an explicit `maxRecords` sized to the window (v4 pagination convention); set `truncated: true` and note it when the cap is hit.
+- **Date keys:** reuse v4's cross-source wake-day convention (sleep → wake-day; recovery/cycle → cycle-start local day via `timezone_offset`).
+- **Baselines / stats:** reuse `stats-utils.ts` (incl. v4 additions `percentile`, `zScore`) and the v4 Tier-1 tool functions directly — do NOT re-derive ACWR or sleep-debt math.
+- **Insufficient-data guard:** every tool declares a minimum N of valid records; below it, returns a clear "insufficient data" message — never NaN/throw.
+- **Output-size convention:** echoed `data_points`/per-night arrays capped at a documented default; stats computed on the full set.
+- **Disclaimer convention:** every interpretive result carries the single canonical string (shared test across all tools):
+  ```
+  disclaimer: "Statistical observation from your data, not medical advice."
+  ```
+
+---
+
+## Tool 1 — `get_daily_recommendation` (ask #5)
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_daily_recommendation` |
+| **Description** | Recommend today's training action (recover / maintain / build) and a target strain band, synthesizing current recovery, recent acute:chronic load, sleep debt, and anomaly flags — personalized to your goal. |
+| **Endpoints** | `/v2/recovery`, `/v2/cycle`, `/v2/activity/sleep` (via the v4 primitives) |
+| **Scopes** | existing |
+| **Depends on** | v4 `get_training_load`, `get_sleep_debt`, `detect_anomalies` |
+
+> **Call-volume note (M3):** This tool runs three paginating primitives plus its own recovery fetch — recovery is fetched ~3× and sleep ~2× per call. The existing 429 retry/backoff covers correctness; the implementation SHOULD dedupe the shared recovery/sleep fetches (single fetch passed into the primitives) where practical. The expected per-call request volume is documented in the handler.
+  planned_sport: z.string().max(80).optional()
+    .describe("Sport you intend to do (echoed back as labeled data; not used for filtering)."),
+})
+// planned_sport is the only freeform field. It is length-capped (≤ 80) and control
+// characters (\r \n \t NUL) are stripped at the handler boundary. It is echoed ONLY
+// into a dedicated structured `planned_sport` echo field / `factors[].state`, never
+// interpolated into the natural-language `summary` (prompt-injection hygiene, sec MED-1).
+```
+
+**Output shape**
+```typescript
+interface DailyRecommendation {
+  evaluated_at: string;                 // ISO 8601
+  goal: "recover" | "maintain" | "build";
+  recovery_score: number | null;        // today's SCORED recovery; null if not yet scored
+  recovery_band: "red" | "yellow" | "green" | "unknown";
+  recommended_action: "rest" | "easy" | "moderate" | "hard";
+  target_strain: { min: number; max: number } | null; // WHOOP 0–21 scale; null when recovery unknown
+  factors: RecommendationFactor[];      // each input that moved the recommendation
+  cautions: string[];                   // e.g. anomaly flags, high ACWR, high sleep debt
+  summary: string;
+  disclaimer: string;
+}
+interface RecommendationFactor {
+  factor: "recovery" | "training_load" | "sleep_debt" | "anomaly";
+  state: string;                        // human-readable (e.g. "ACWR 1.6 — high_risk")
+  influence: "raised" | "lowered" | "neutral"; // direction it pushed the recommendation
+}
+```
+
+**Algorithm (heuristic, fully documented — all constants named)**
+
+Action ladder (ordered, floor = `rest`): `hard` → `moderate` → `easy` → `rest`. "One step toward rest" moves right; "one step toward hard" moves left. Steps never underflow past `rest` or overflow past `hard`.
+
+Named constants (module-level, shared where noted):
+- `RECOVERY_ZONES` — `< 34` red, `34–66` yellow, `> 66` green. **Extracted into one shared constant imported by both this tool and the v4 primitives** (sec M5 / DRY — single source of truth for WHOOP's zone cutoffs).
+- `SLEEP_DEBT_CAUTION_HOURS = 5` — `get_sleep_debt.total_debt_hours` above this is a caution.
+- `TARGET_STRAIN_BY_ACTION` — deterministic, **disjoint** bands keyed on the FINAL action (see step 5).
+
+1. Fetch the latest SCORED recovery for **today in the user's local day** (derived from the latest cycle's `timezone_offset`, per the v4 wake-day convention — not UTC). Map to band via `RECOVERY_ZONES`. No SCORED recovery for today → `recovery_band: "unknown"`, base action `easy`, `target_strain: null`, summary notes the gap.
+2. Base action from band: red→`easy`, yellow→`moderate`, green→`hard`. (Red is `easy` by default; it becomes `rest` only when step 3 adds a caution — M1.)
+3. **Each active caution applies exactly one step toward rest** (cumulative, capped at the `rest` floor): `detect_anomalies.flagged === true`; `get_training_load.acwr_zone === "high_risk"`; `get_sleep_debt.total_debt_hours > SLEEP_DEBT_CAUTION_HOURS`. Each appends a `factors` entry (`influence: "lowered"`) and a `cautions` entry. Three cautions on a green day → `hard`→3 steps→`rest`.
+4. **Goal modifies last:** `recover` applies one additional step toward rest (capped at `rest`); `build` applies one step toward hard **only if zero cautions are active AND recovery is not red** (never escalates past a caution or a red recovery). `maintain` is neutral.
+5. `target_strain` is derived from the **FINAL `recommended_action`** (not the raw recovery band — I1), via `TARGET_STRAIN_BY_ACTION` with disjoint bands: `rest` `{0,4}`, `easy` `{4,8}`, `moderate` `{8,14}`, `hard` `{14,18}`. Output is clamped to `[0,21]` purely as a defensive guard (the mapping never exceeds it). `recovery_band: "unknown"` → `target_strain: null`.
+6. If any underlying primitive returns "insufficient data", that factor is marked `neutral` with a note (it applies no step), the other factors still contribute, and the summary states the recommendation is partial — never a throw.
+
+**Acceptance criteria**
+- [ ] "Today" is resolved in the user's LOCAL day via the latest cycle's `timezone_offset` (not UTC); a near-local-midnight fixture proves the correct cycle is chosen.
+- [ ] Recovery band uses the shared `RECOVERY_ZONES` constant (same constant the v4 primitives import); cutoff tests at 33/34 and 66/67.
+- [ ] `target_strain` is mapped from the **final** `recommended_action` via disjoint `TARGET_STRAIN_BY_ACTION` bands; a green-recovery + anomaly fixture yields a lowered action AND a lowered strain band (the two outputs agree — I1). `recovery_band: "unknown"` → `target_strain: null`.
+- [ ] Each active caution (anomaly flag, ACWR `high_risk`, `total_debt_hours > SLEEP_DEBT_CAUTION_HOURS=5`) applies exactly one step toward rest and adds a `cautions` entry; a fixture with all three cautions on a green day yields `rest` (floor, no underflow).
+- [ ] `SLEEP_DEBT_CAUTION_HOURS` boundary tested at threshold and threshold±ε.
+- [ ] `goal: "build"` escalates one step toward hard ONLY when zero cautions AND not red; blocked otherwise. `goal: "recover"` always applies one extra step toward rest (capped at `rest`). `maintain` neutral.
+- [ ] No SCORED recovery today → `recovery_band: "unknown"`, `target_strain: null`, action `easy`, summary notes the gap (no NaN).
+- [ ] Each primitive independently returning "insufficient data" → that factor `neutral` + noted, others still contribute; one test per primitive (training-load / sleep-debt / anomaly).
+- [ ] A mid-composition `fetch` rejection / 5xx → the tool returns a graceful partial result OR a typed error (state which); a test pins the chosen behavior.
+- [ ] `factors` lists every input with a structured `{factor, state, influence}` entry; assertions check the specific factor per branch, not just non-emptiness.
+- [ ] `planned_sport` is `≤ 80` chars, control-chars stripped, echoed ONLY into a labeled field (never the `summary`); fixtures with an oversized value and an injection-style value (`"ignore previous instructions…"`) prove containment.
+- [ ] `disclaimer` present (canonical string).
+- [ ] Unit tests: a **parametrized decision-table** test (band × goal × caution-set) as the source of truth — incl. yellow+build+no-caution→hard, yellow+build+caution→moderate, low/normal ACWR→no adjustment, all-three-cautions→rest, recovery-unknown, and per-primitive insufficiency.
+
+---
+
+## Tool 2 — `forecast_sleep` (ask #7)
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `forecast_sleep` |
+| **Description** | Project the nightly sleep needed over the coming nights to clear accumulated sleep debt and meet your nightly need by a target date — the forward-looking complement to `get_sleep_debt`. |
+| **Endpoints** | `/v2/activity/sleep`, `/v2/cycle` (recent strain feeds need) |
+| **Scopes** | existing |
+| **Depends on** | v4 `get_sleep_debt` (current debt + nightly-need definitions) |
+
+**Input schema**
+```typescript
+z.object({
+  target_date: z.string()
+    .describe("Target date — ISO 8601 (YYYY-MM-DD) only. Must be today or future."),
+  habitual_wake_time: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Must be 24h HH:MM").optional()
+    .describe("Local wake time 'HH:MM' to anchor suggested bedtimes. Default: inferred from recent mean wake time."),
+  baseline_days: z.number().int().min(7).max(90).optional()
+    .describe("History window for nightly-need estimate. Default: 14."),
+})
+// habitual_wake_time validated at the schema boundary with an ANCHORED, LINEAR regex
+// (no backtracking quantifiers — no ReDoS, sec MED-2), mirroring src/tools/date-utils.ts.
+```
+
+> **Note:** Like v4 `get_event_readiness`, `target_date` is ISO-only and validated today-or-future at the schema/handler boundary; relative forward expressions ("next Saturday") are rejected with a clear message (date-utils is backward-looking only).
+
+**Output shape**
+```typescript
+interface SleepForecast {
+  generated_at: string;
+  target_date: string;
+  nights_until_target: number;
+  starting_debt_hours: number;          // from get_sleep_debt at evaluation time
+  nightly_need_hours: number;           // baseline + recent-strain + recent-nap (v4 definition, excludes debt component)
+  plan: ForecastNight[];
+  projected_debt_at_target_hours: number; // residual debt if the plan is followed
+  summary: string;
+  disclaimer: string;
+}
+interface ForecastNight {
+  date: string;                         // wake-up day (YYYY-MM-DD)
+  recommended_sleep_hours: number;      // nightly_need + a share of debt repayment
+  suggested_bedtime_local: string | null; // wake_time - recommended_sleep_hours; null if wake time unknown
+  debt_remaining_hours: number;         // running residual after this night
+}
+```
+
+**Algorithm (heuristic projection, not a prediction)** — named constant `MAX_NIGHTLY_SLEEP_HOURS = 10`.
+
+1. **`starting_debt_hours` (pinned — I2):** the **standing** debt = most recent SCORED night's `need_from_sleep_debt_milli` (milli→hours). This is WHOOP's own running accumulation and is the physiologically meaningful "debt to clear" — deliberately NOT `get_sleep_debt.total_debt_hours` (which is a backward *sum* that scales with the window and would make the forecast depend arbitrarily on `baseline_days`). Documented as a deliberate deviation from `get_sleep_debt`.
+2. **`nightly_need_hours` (pinned — I3):** the **mean** of `get_sleep_debt.nights[].needed_hours` over the non-nap main-sleep nights in the window (each night's need already EXCLUDES the debt component per v4). `wake_time` for bedtime math is `habitual_wake_time` if supplied, else the mean local wake clock-time over those same nights.
+3. **Per-night recommended sleep:** `recommended_sleep_hours = min(MAX_NIGHTLY_SLEEP_HOURS, nightly_need_hours + (debt_remaining / nights_left))`. Debt that the cap leaves unrepaid on a night **rolls forward** to subsequent nights' `debt_remaining`; whatever remains after the last night becomes `projected_debt_at_target_hours` (so `debt_remaining_hours` is an unambiguous running residual — M4).
+4. `suggested_bedtime_local = wake_time − recommended_sleep_hours` in **local** time; `null` when no wake time supplied and none inferable. (Local-time subtraction is DST-sensitive — see tests.)
+5. `nights_until_target = 0` (target is today) → single-night plan from current standing debt, no multi-night spread.
+6. Explicitly labeled a heuristic projection in `summary` (sleep need re-computes nightly as strain/naps change).
+
+**Acceptance criteria**
+- [ ] `target_date` ISO-only, today-or-future; past dates and relative expressions rejected with clear messages. **The today/past check uses the user's LOCAL day** (consistent with `plan[].date` wake-day labels), and `nights_until_target` is the local-day difference — a near-local-midnight fixture proves the count matches the labeled nights (no UTC off-by-one — I5).
+- [ ] `starting_debt_hours` = most recent SCORED night's `need_from_sleep_debt_milli` (standing debt), and is invariant to `baseline_days`; a fixture varying `baseline_days` proves `starting_debt_hours` does not scale with the window.
+- [ ] `nightly_need_hours` = mean of v4 per-night `needed_hours` over non-nap nights (excludes the debt component — no double counting); a fixture pins the mean.
+- [ ] Per-night `recommended_sleep_hours = min(10, need + debt_share)`; debt above the cap rolls forward; final residual = `projected_debt_at_target_hours`; `debt_remaining_hours` is the running residual.
+- [ ] `suggested_bedtime_local` computed in local time from `wake_time`; `null` when wake time unknown; a DST-crossing fixture asserts the local-time subtraction is correct.
+- [ ] `nights_until_target === 0` → single-night plan, no error.
+- [ ] Zero-debt and sleep-surplus (negative standing debt) inputs handled: recommended sleep floors at `nightly_need_hours`, residual `0`.
+- [ ] `habitual_wake_time` malformed input rejected at the schema boundary (anchored regex).
+- [ ] < the minimum valid nights for a need estimate → "insufficient data" message.
+- [ ] `truncated` flag honored per pagination convention.
+- [ ] Projection labeled heuristic, not medical/performance guarantee.
+- [ ] `disclaimer` present.
+- [ ] Unit tests: multi-night roll-forward split, single-night (target today), per-night cap applied (large debt) with roll-forward, zero-debt, negative standing debt, wake-time-unknown bedtime null, DST-crossing bedtime, local-midnight boundary, past-date rejected, relative-expression rejected, malformed-wake-time rejected, insufficient-data.
+
+---
+
+## Tool 3 — `get_benchmarks` (ask #10)
+
+| Field | Value |
+|-------|-------|
+| **MCP name** | `get_benchmarks` |
+| **Description** | Place your personal HRV, resting heart rate, respiratory rate, and sleep duration against published age/sex population norms, alongside your own rolling baseline — with explicit comparability caveats. |
+| **Endpoints** | `/v2/recovery`, `/v2/activity/sleep` (via v4 `get_baselines`) + bundled static norm tables |
+| **Scopes** | existing |
+| **Depends on** | v4 `get_baselines` |
+
+**Input schema**
+```typescript
+z.object({
+  age: z.number().int().min(18).max(100).optional()
+    .describe("Your age in years (18+). REQUIRED for population comparison — the WHOOP API does not expose age. Omit to get personal baselines only."),
+  sex: z.enum(["male", "female"]).optional()
+    .describe("Biological sex for sex-specific norms (RHR, HRV). Omit to fall back to combined norms where available."),
+  baseline_days: z.number().int().min(14).max(180).optional()
+    .describe("Personal baseline window. Default: 30."),
+})
+```
+
+> **Critical constraint (verified):** The WHOOP v2 profile exposes **no age/DOB**. `age` and `sex` are therefore **user inputs**. When `age` is omitted, the tool returns personal baselines only and a note that population context requires an age.
+
+**Output shape**
+```typescript
+interface BenchmarkReport {
+  age: number | null;
+  sex: "male" | "female" | null;
+  metrics: Record<BenchmarkMetric, BenchmarkBand | null>; // null when insufficient personal data
+  caveats: string[];                    // comparability caveats (see below)
+  disclaimer: string;
+}
+type BenchmarkMetric = "hrv" | "rhr" | "respiratory_rate" | "sleep_hours";
+interface BenchmarkBand {
+  personal_mean: number;                // from get_baselines
+  personal_sample_size: number;
+  population: PopulationContext | null; // null when age missing or no norm for this metric/age/sex
+}
+interface PopulationContext {
+  source: string;                       // citation key into the bundled norm table
+  source_version: string;               // publication year / dataset version (auditability)
+  age_band: string;                     // e.g. "35–39"
+  p5: number; p10: number; p25: number; p50: number; p75: number; p90: number; p95: number;
+  user_percentile: number | null;       // where personal_mean falls (see percentile model)
+  beyond_published_range: boolean;       // true when personal_mean is outside [p5, p95]
+  interpretation: string;               // DESCRIPTIVE, non-diagnostic, caveat co-located
+}
+```
+
+**Percentile model (pinned — I4)**
+`user_percentile` is computed by **piecewise-linear interpolation** between the published anchors `{p5,p10,p25,p50,p75,p90,p95}` mapped to `{5,10,25,50,75,90,95}`. A `personal_mean` below `p5` or above `p95` is **clamped to [1, 99]** (never 0/100) and `beyond_published_range: true` is set with a "beyond published range" note. The extra anchors (p5/p10/p90/p95 beyond the original p25/p50/p75) exist specifically so the tails are interpolatable rather than guessed.
+
+**Norm-table design**
+- Norms live in a **bundled static data module** (`src/tools/benchmark-norms.ts`) — typed constants, no network, no new dependency. Each row carries `source` AND `source_version` for auditability.
+- Age bands are **contiguous and non-overlapping** and cover **adults only** (18+); the input `age.min(18)` matches table coverage so the "no norm for band" path is the exception, not the norm.
+- Tables cover, at minimum: resting heart rate by age/sex, sleep duration by age, respiratory rate (adult range). **HRV norms are method-dependent** (see caveats) and included only if a defensible RMSSD-comparable source is used.
+- `interpretation` strings are constrained to **descriptive, non-diagnostic** phrasing (e.g. "above the 50th percentile for your age band"), never implied diagnosis; the disclaimer is co-located.
+
+**Mandatory caveats (always in `caveats`)**
+- HRV (RMSSD) is highly method- and time-of-day dependent; WHOOP's overnight RMSSD is **not** directly comparable to morning or lab measurements — treat population HRV percentiles as rough context only.
+- Population norms describe groups, not individuals; "normal for your age" is not "optimal for you" — the personal baseline is the more meaningful reference.
+
+**Acceptance criteria**
+- [ ] `age` omitted → personal baselines returned, `population: null` for every metric, a note explaining age is required for population context (no error).
+- [ ] `age` present → population band looked up by age band (and `sex` when provided) from the bundled table; `user_percentile` computed via the pinned piecewise-linear model.
+- [ ] `sex` omitted but `age` present → falls back to combined-sex norms where available; metrics with only sex-specific norms → `population: null` with a reason.
+- [ ] `user_percentile` model tested at exact anchors (p25/p50/p75 → 25/50/75), between knots (interpolated), and beyond p5/p95 (clamped to [1,99] + `beyond_published_range: true`).
+- [ ] No norm entry for a metric/age/sex combination → that metric's `population: null` with a reason (not a throw).
+- [ ] `age`/`sex` are NEVER read from the WHOOP API — a test asserts `fetch` is never called with the profile URL during a benchmark run.
+- [ ] `age`/`sex` and benchmark output are NEVER written to disk, the token store, or `ResourceCache` (in-process only).
+- [ ] Each population entry carries `source` + `source_version` resolvable to the bundled table.
+- [ ] Mandatory caveats always present: HRV-comparability, group-vs-individual, and (the spec ships adult-only norms) an adult-derived-norms note.
+- [ ] `interpretation` strings contain no diagnostic language (asserted) and co-locate the disclaimer.
+- [ ] `truncated`/insufficient-window notes from the underlying `get_baselines` are propagated.
+- [ ] Metrics with insufficient personal data → `null` band.
+- [ ] Output schema has NO partner/friend field (asserted structurally), confirming single-user scope.
+- [ ] `disclaimer` present.
+- [ ] Norm-table **structural-invariant** tests: `p5<p10<p25<p50<p75<p90<p95` monotonic per row, age bands contiguous + non-overlapping (boundary test e.g. 29 vs 30), valid sex keys.
+- [ ] Unit tests: age-present full lookup, age-missing baselines-only, sex-omitted combined fallback, no-norm-for-band null, percentile at anchors/between/beyond, insufficient personal data, caveats always present, no-API-for-age, no-persist.
+
+> **OPEN DECISION D-2:** Which published norm sources/tables to bundle, and their licensing for redistribution in the repo. HRV norms specifically need a source whose measurement method is reasonably comparable to WHOOP overnight RMSSD, or HRV population context is dropped (personal baseline only).
+
+---
+
+## Prompt — `daily_coaching` (ask #4)
+
+A static MCP prompt (mirrors the existing 5 in `src/prompts/index.ts`) that orchestrates a coaching conversation: instructs the assistant to call `get_daily_recommendation`, `get_today`, `get_sleep_debt`, and `detect_anomalies`, then reason over them together and respond with a recommendation + rationale + the non-medical-advice caveat.
+
+**Input schema (prompt args)**
+```typescript
+{ goal: z.string().optional().describe("Training intent: recover | maintain | build (default maintain)") }
+```
+
+**Acceptance criteria**
+- [ ] Registered with a `snake_case` name and an optional `goal` arg.
+- [ ] Message text references the real tool names above and asks for a concrete recommendation + rationale + caveat.
+- [ ] Unit test asserts registration and that the rendered text names the orchestrated tools.
+
+---
+
+## Deferred / Out of Scope
+
+| Ask | Decision | Rationale |
+|-----|----------|-----------|
+| #9 proactive illness/overtraining **alerts** | **Deferred → 0.7.0** | Detection already exists (`detect_anomalies`). Proactive *push* needs webhooks + scheduled checks — a transport/hosting concern reserved on the v3 roadmap, not an analytics tool. |
+| #8 cross-app integration (Strava/Apple Health/calendar) | **Non-goal** | A multi-connector problem solved at the assistant level with other MCP servers; keep this server WHOOP-focused. |
+| Partner/friend benchmarking | **Non-goal** | Single-user OAuth — no access to another user's data. |
+
+> **OPEN DECISION D-3:** Confirm webhooks/proactive alerts stay on the 0.7.0 track (vs. pulling a scheduled-check stub into 0.6.0).
+
+---
+
+## Project Structure (additions)
+
+```
+src/tools/
+  get-daily-recommendation.ts    # Tool 1
+  forecast-sleep.ts              # Tool 2
+  get-benchmarks.ts              # Tool 3
+  benchmark-norms.ts             # Bundled static norm tables (data module, no logic)
+src/prompts/index.ts             # MODIFY — register daily_coaching prompt
+src/server.ts                    # MODIFY — register the 3 new tools
+tests/tools/                     # mirror each new file with *.test.ts
+tests/prompts/                   # daily_coaching registration test
+```
+
+One tool per file; Zod schema + handler co-located; named exports; explicit return types. Tool names `snake_case`, files `kebab-case.ts`, types `PascalCase`, functions `camelCase`.
+
+---
+
+## Code Style (matches existing tools)
+
+```typescript
+// src/tools/get-daily-recommendation.ts
+import { z } from "zod";
+import type { WhoopClient } from "../api/client.js";
+import { getTrainingLoad } from "./get-training-load.js";
+import { getSleepDebt } from "./get-sleep-debt.js";
+import { detectAnomalies } from "./detect-anomalies.js";
+
+export const getDailyRecommendationSchema = {
+  name: "get_daily_recommendation",
+  description:
+    "Recommend today's training action (recover / maintain / build) and a target " +
+    "strain band from current recovery, recent load, sleep debt, and anomaly flags.",
+  inputSchema: z.object({
+    goal: z.enum(["recover", "maintain", "build"]).optional()
+      .describe("Your training intent today. Default: 'maintain'."),
+    planned_sport: z.string().optional()
+      .describe("Sport you intend to do (echoed into the rationale)."),
+  }),
+};
+
+export async function getDailyRecommendation(
+  client: WhoopClient,
+  params: { goal?: "recover" | "maintain" | "build"; planned_sport?: string }
+): Promise<DailyRecommendation> {
+  // ... compose v4 primitives, apply documented heuristic, return recommendation ...
+}
+```
+
+---
+
+## Testing Strategy
+
+- **TDD** — failing test first, then implement (Prove-It for any bug).
+- **Mock the WHOOP API** — `vi.fn()` over `globalThis.fetch`; never hit the real API. Compose tools by mocking the underlying fetch, not the v4 functions, so integration through the primitives is exercised.
+- **Fixture provenance** — maintain a documented table mapping each raw fetch fixture to the exact primitive output it produces (e.g. "N records below the min → `acwr_zone: insufficient_data`"), citing the v4 threshold it relies on, so composition tests aren't brittle against primitive internals. **Tie every fixture record timestamp to the fixed fake clock** so "today"/"last-N-days" windows are stable. If any primitive follows `next_token`, include at least one multi-page fixture (or note primitives are single-page within these windows).
+- **Deterministic time** — `vi.useFakeTimers()` with a FIXED system time for every tool touching "today" / "nights until target"; timers restored in `afterEach`. Local-midnight and DST-crossing fixtures pin explicit `timezone_offset`s.
+- **Per-tool tests** — at minimum: happy path, insufficient-data, missing/PENDING records, boundary (recovery band edges, target-date today/past, age present/absent), and the `truncated` path where pagination caps apply.
+- **Heuristic-boundary tests** — recovery band cutoffs (33/34, 66/67), target-strain clamping at [0,21], sleep-night cap, percentile at extremes — each fixture annotated with its hand-computed expected value.
+- **No-API-for-age test** — `get_benchmarks` must not consult the profile endpoint for `age`/`sex`.
+- **Shared disclaimer test** — one parametrized test asserts every new interpretive tool output carries the exact canonical disclaimer string.
+- **Server/prompt registration test** — assert the 3 new tools and `daily_coaching` prompt are registered with unique `snake_case` names and valid Zod schemas (catches a tool implemented but never wired up).
+- **Coverage targets** — new tools and `benchmark-norms.ts` consumers held to > 80% **line and branch** (decision-heavy heuristics need branch coverage); > 80% on `src/auth/` and `src/api/` (unchanged); > 70% overall.
+- **Finiteness invariant** — a parametrized assertion that every numeric output field is finite (no NaN/Infinity) across all fixtures, cheaply guarding every band/clamp/split/percentile path.
+- Run `npm test` after every increment; `npm run lint && npm run typecheck && npm run build` must be green before any commit.
+
+---
+
+## Boundaries
+
+**Always**
+- Validate all tool input with Zod; reject out-of-range windows and non-future `target_date`s at the schema layer.
+- Reuse v4 primitives (`get_training_load`, `get_sleep_debt`, `get_baselines`, `detect_anomalies`) — never re-derive ACWR / sleep-debt / baseline math.
+- Return a clear "insufficient data" message (never NaN/throw) below each tool's minimum.
+- Attach the canonical non-medical-advice `disclaimer` to every interpretive result.
+- Run tests + lint + typecheck + build before committing.
+
+**Ask first**
+- Bundling specific published norm tables and confirming their redistribution licensing (D-2).
+- Any new runtime dependency (none anticipated).
+- Pulling proactive-alert/webhook scaffolding into 0.6.0 (D-3).
+
+**Never**
+- Add new OAuth scopes (none needed).
+- Read age/DOB from the WHOOP API (it isn't there) — `age`/`sex` are user inputs only.
+- **Log tool inputs (especially `age`/`sex`/`planned_sport`) or computed health values** — log only tool name, requestId, and duration (sec LOW-1/LOW-2). Error and "insufficient data" messages must not embed `age`/`sex` or raw metric values beyond what the user-facing explanation needs.
+- **Persist `age`/`sex` or benchmark output** to disk, the token store, or `ResourceCache` — these tools are in-process only (sec LOW-3).
+- **Convert `benchmark-norms` to a remote-fetched or user-importable source** — it must remain a bundled static module; changing that re-introduces the untrusted-input/integrity surface v4 Tier 4 was gated for and requires a fresh security pass (sec INFO-1).
+- Hit the real WHOOP API in tests.
+- Send any user data to a network endpoint other than WHOOP's read APIs.
+- Use `any`; commit secrets; remove or skip failing tests.
+- Present statistical or heuristic output as medical advice.
+
+---
+
+## Success Criteria (verifiable)
+
+- [ ] **D-1 decided** (bundle with v4 as 0.6.0 vs. follow-on) and reflected in `package.json` + `CHANGELOG.md`.
+- [ ] v4 Tier-1 primitives present and imported (prerequisite); this layer adds no duplicate analytics math.
+- [ ] `get_daily_recommendation`, `forecast_sleep`, `get_benchmarks` implemented, registered, and passing all acceptance criteria — verify: `npm test -- tests/tools/`.
+- [ ] `daily_coaching` prompt registered and tested.
+- [ ] `get_benchmarks` returns personal-only output with a clear note when `age` is omitted, and never reads age from the API.
+- [ ] Every interpretive tool output includes the canonical disclaimer — verified via a shared test.
+- [ ] No new runtime dependencies in `package.json`; no new OAuth scopes.
+- [ ] `npm run lint && npm run typecheck && npm run build` clean; coverage thresholds met.
+- [ ] README + CHANGELOG updated; tool count updated.
+
+---
+
+## Open Questions (consolidated)
+
+| ID | Question | Spec default |
+|----|----------|--------------|
+| D-1 | Ship coaching layer bundled with v4 as 0.6.0, or as a follow-on point release? **Conditional on v4's own D-1.** | Bundle as 0.6.0 (Option A) |
+| D-2 | Which published norm sources to bundle for `get_benchmarks`, with `source_version` + redistribution licensing? Adult-only (18+); HRV included only if RMSSD-comparable. | Pending source decision |
+| D-3 | Proactive alerts/webhooks stay on 0.7.0? | Yes — deferred |
+
+---
+
+## Sub-Agent Review Summary (incorporated 2026-06-13)
+
+The draft was reviewed by `code-reviewer`, `security-auditor`, and `test-engineer`. No Critical/High architectural or security defects were found; the layer is materially lower-risk than v4 Tier 4 (no new scopes, deps, persistence, or untrusted-input surface). Material findings and their resolution:
+
+| Finding | Source | Resolution in this spec |
+|---------|--------|-------------------------|
+| **I1** — `target_strain` derived from raw band, contradicting the adjusted action | code-reviewer / test-engineer | `target_strain` now maps from the FINAL `recommended_action` via disjoint `TARGET_STRAIN_BY_ACTION` bands; agreement asserted. |
+| **I2** — `forecast_sleep` starting debt scaled arbitrarily with `baseline_days` | code-reviewer | Pinned `starting_debt_hours` to the latest night's `need_from_sleep_debt_milli` (standing debt), invariant to window. |
+| **I3** — `nightly_need_hours` aggregation undefined | code-reviewer / test-engineer | Defined as mean of v4 per-night `needed_hours` over non-nap nights. |
+| **I4 / percentile model** — percentile undefined from 3 quantiles | code-reviewer / test-engineer | Added p5/p10/p90/p95 anchors + piecewise-linear model, clamped [1,99] with `beyond_published_range`. |
+| **I5 / timezone** — UTC vs local-day inconsistency | code-reviewer / test-engineer | "Today" and `nights_until_target` use the local wake-day convention; midnight + DST fixtures added. |
+| **Multi-caution semantics** — step ladder undefined | test-engineer | Defined ordered action ladder, one step per caution, goal applied last, floor at `rest`; decision-table test required. |
+| **Pinned constants** — "high debt" / red action vague | code-reviewer / test-engineer | Named `SLEEP_DEBT_CAUTION_HOURS=5`, `MAX_NIGHTLY_SLEEP_HOURS=10`, shared `RECOVERY_ZONES`. |
+| **MED-1** — `planned_sport` freeform injection surface | security-auditor | Capped `.max(80)`, control-chars stripped, echoed only into a labeled field, never `summary`; injection fixture. |
+| **MED-2** — `habitual_wake_time` unvalidated / ReDoS | security-auditor | Anchored linear `HH:MM` regex at the schema boundary. |
+| **MED-3** — norm-table liability, minors, `interpretation` wording | security-auditor | `age.min(18)`; adult-derived-norms caveat; non-diagnostic `interpretation` (asserted); `source_version` per row. |
+| **LOW-1/2/3, INFO-1** — logging/persistence/drift | security-auditor | "Never" boundaries: no-log inputs/health values, no-persist `age`/`sex`/output, norms must stay a bundled static module. |
+| **M3** — multiplied API call volume | code-reviewer | Documented; dedupe shared recovery/sleep fetch where practical. |
+| **M6 / truncated** — benchmark doesn't surface `truncated` | code-reviewer | Propagate `truncated`/insufficient-window from `get_baselines`. |
+| **Test rigor** — fixture provenance, per-primitive insufficiency, fetch-rejection path, branch coverage, finiteness invariant, norm-table structural invariants, registration substrings | test-engineer | Folded into Testing Strategy + per-tool acceptance criteria. |
+
+Deferred-by-design (confirmed sound): webhooks/proactive alerts → 0.7.0 (D-3); cross-app integration and partner benchmarking → non-goals.
+
+---
+
+## Acceptance Definition
+
+This spec is "done" (ready for the Plan phase) when:
+1. The human has resolved D-1 through D-3.
+2. ✅ `code-reviewer`, `security-auditor`, and `test-engineer` sub-agents have reviewed and their findings are incorporated (see summary above).
+3. The human approves the final scope.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "whoop-ai-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "whoop-ai-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -225,9 +225,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -361,9 +361,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -429,9 +429,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -463,9 +463,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -642,37 +642,51 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1544,9 +1558,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1568,8 +1582,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1578,15 +1592,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1595,13 +1609,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1622,9 +1636,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1635,13 +1649,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1650,13 +1664,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1665,9 +1679,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1678,13 +1692,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1830,20 +1844,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1853,17 +1867,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -2144,9 +2171,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2156,9 +2183,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2169,32 +2196,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escape-html": {
@@ -2563,9 +2590,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -2807,9 +2834,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2867,9 +2894,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2879,9 +2906,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2957,9 +2984,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3311,9 +3338,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.19.tgz",
+      "integrity": "sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug==",
       "dev": true,
       "funding": [
         {
@@ -3546,9 +3573,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -3566,7 +3593,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3624,12 +3651,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3824,14 +3852,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -4145,9 +4173,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.6.tgz",
+      "integrity": "sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4195,490 +4223,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4693,17 +4237,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -4756,13 +4317,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -4854,20 +4415,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -4897,8 +4458,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whoop-ai-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "mcpName": "io.github.shashankswe2020-ux/whoop",
   "description": "MCP server wrapping the WHOOP REST API for AI assistant access to health and fitness data",
   "type": "module",

--- a/site/index.html
+++ b/site/index.html
@@ -7,7 +7,7 @@
     <title>whoop-mcp: Your WHOOP data, in any AI assistant</title>
     <meta
       name="description"
-      content="An MCP server that wraps the WHOOP REST API, so AI assistants can query your recovery, sleep, strain, and workouts through natural conversation."
+      content="Connect WHOOP to AI assistants. Preview 0.7.0: personal baselines, sleep debt, structured results, and optional aggregate-only access."
     />
     <meta property="og:title" content="whoop-mcp" />
     <meta property="og:description" content="Your WHOOP data, in any AI assistant." />
@@ -29,8 +29,8 @@
          ===================================================================== */
 
       :root {
-        --font: 'Archivo', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
-        --mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+        --font: "Archivo", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+        --mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
         /* light / paper (default) */
         --paper: #f7f6f2;
@@ -237,6 +237,74 @@
         letter-spacing: 0.01em;
       }
 
+      .release-label {
+        margin: 0 0 1rem;
+        font-family: var(--mono);
+        font-size: 0.85rem;
+        color: var(--ink-2);
+      }
+      .release {
+        padding: 3rem 2rem;
+        border-top: 1px solid var(--rule);
+      }
+      .release h2 {
+        font-size: 2rem;
+        letter-spacing: 0;
+        margin: 0 0 1rem;
+      }
+      .release-intro,
+      .release-note {
+        max-width: 78ch;
+        color: var(--ink-2);
+        line-height: 1.6;
+      }
+      .release a {
+        color: var(--ink);
+        text-underline-offset: 3px;
+      }
+      .release-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 2rem;
+        margin: 2rem 0;
+      }
+      .release-item {
+        border-top: 1px solid var(--rule-soft);
+        padding-top: 1rem;
+        min-width: 0;
+      }
+      .release-item h3 {
+        font-size: 1.15rem;
+        letter-spacing: 0;
+        margin: 0 0 0.65rem;
+      }
+      .release-item p {
+        line-height: 1.6;
+        color: var(--ink-2);
+        margin: 0;
+      }
+      .release code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        overflow-wrap: anywhere;
+      }
+      .install {
+        max-width: 100%;
+      }
+      .install code {
+        min-width: 0;
+        overflow-wrap: anywhere;
+      }
+      .copy {
+        flex-shrink: 0;
+        min-width: 32px;
+        min-height: 32px;
+      }
+      :focus-visible {
+        outline: 2px solid var(--ink);
+        outline-offset: 4px;
+      }
+
       /* ---- hero diagram ---- */
       .graph {
         width: 100%;
@@ -281,7 +349,7 @@
         border-inline-start: 1px solid var(--rule);
       }
       .feature::before {
-        content: '';
+        content: "";
         grid-column: 2;
         grid-row: 1 / 3;
         align-self: stretch;
@@ -433,6 +501,12 @@
 
       /* ---- responsive ---- */
       @media (max-width: 860px) {
+        .release {
+          padding: 2.5rem 1.25rem;
+        }
+        .release-grid {
+          grid-template-columns: 1fr;
+        }
         .hero {
           grid-template-columns: 1fr;
         }
@@ -463,6 +537,11 @@
         }
         .nav {
           padding: 1rem 1.25rem;
+          flex-wrap: wrap;
+          gap: 0.75rem;
+        }
+        .wordmark {
+          flex-shrink: 0;
         }
         .nav-links {
           gap: 0.85rem;
@@ -490,6 +569,7 @@
       <header class="nav">
         <a class="wordmark" href="./">whoop-mcp</a>
         <nav class="nav-links">
+          <a href="#release">0.7.0 preview</a>
           <a href="https://github.com/shashankswe2020-ux/whoop-mcp#readme">Docs</a>
           <a class="opt" href="https://www.npmjs.com/package/whoop-ai-mcp">npm</a>
           <a href="https://github.com/shashankswe2020-ux/whoop-mcp">GitHub</a>
@@ -502,18 +582,14 @@
       <main>
         <section class="hero">
           <div class="hero-left">
+            <p class="release-label">Published: 0.6.1 / Next: 0.7.0</p>
             <h1>Your WHOOP data, in any AI assistant</h1>
             <p class="lede">
-              An MCP server that wraps the WHOOP REST API, so Claude, Cursor, and any MCP
-              client can read your recovery, sleep, strain, and workouts through natural
-              conversation.
+              An MCP server that wraps the WHOOP REST API, so Claude, Cursor, and any MCP client can
+              read your recovery, sleep, strain, and workouts through natural conversation.
             </p>
             <div class="cta">
-              <a
-                class="btn btn-primary"
-                href="#setup"
-                >Get started</a
-              >
+              <a class="btn btn-primary" href="#setup">Get started</a>
               <a class="btn btn-ghost" href="https://www.npmjs.com/package/whoop-ai-mcp"
                 >View on npm</a
               >
@@ -534,7 +610,7 @@
                 </svg>
               </button>
             </div>
-            <p class="stat">14 tools · 4 resources · 5 prompts · stdio + HTTP transport</p>
+            <p class="stat">0.7.0 preview: 16 tools · 4 resources · 5 prompts in standard mode</p>
           </div>
 
           <div class="hero-right">
@@ -607,8 +683,8 @@
             </svg>
             <h2>Recovery, sleep &amp; strain</h2>
             <p>
-              14 tools for recovery scores, HRV, resting heart rate, sleep stages, daily
-              strain, and workouts, plus weekly summaries, trends, and period comparisons.
+              Read recovery scores, HRV, resting heart rate, sleep stages, daily strain, and
+              workouts, plus weekly summaries, trends, and period comparisons.
             </p>
           </article>
 
@@ -625,8 +701,8 @@
             </svg>
             <h2>MCP-native</h2>
             <p>
-              Tools, resources, and prompts over stdio or Streamable HTTP. Drop it into
-              Claude Desktop, or host it remotely for any MCP client.
+              Tools, resources, and prompts over stdio or Streamable HTTP. Drop it into Claude
+              Desktop, or host it remotely for any MCP client.
             </p>
           </article>
 
@@ -645,19 +721,81 @@
             </svg>
             <h2>Private by design</h2>
             <p>
-              Read-only OAuth2 with PKCE. Tokens stay on your machine at
-              <code>~/.whoop-mcp</code> with 0600 permissions, and the real API is never
-              touched in tests.
+              Read-only tools with OAuth and PKCE. Tokens stay on the server host with 0600
+              permissions. Health results reach your assistant provider; the 0.7.0 preview adds
+              optional aggregate-only access.
             </p>
           </article>
         </section>
 
+        <section class="release" id="release" aria-labelledby="release-title">
+          <p class="release-label">Upcoming release / 0.7.0 / Not yet on npm</p>
+          <h2 id="release-title">Personal analytics, grounded in your history</h2>
+          <p class="release-intro">
+            Two new tools join the existing fourteen, with clearer data quality and control over
+            what your assistant receives. These features are implemented in the release work,
+            pending final client checks and publication.
+          </p>
+          <div class="release-grid">
+            <article class="release-item">
+              <h3>What is typical for you?</h3>
+              <p>
+                <code>get_baselines</code> compares HRV, resting heart rate, sleep and recovery with
+                your own history. Percentile bands exclude the latest observation and current local
+                day. Fewer than 14 historical points returns an insufficient-data result, not a
+                guessed normal range.
+              </p>
+            </article>
+            <article class="release-item">
+              <h3>Sleep deficit, without double counting</h3>
+              <p>
+                <code>get_sleep_debt</code> separates observed nightly deficits from WHOOP's
+                standing debt. It uses scored asleep stages, accounts for naps, and describes local
+                sleep consistency. These are observations, not recovery forecasts or medical advice.
+              </p>
+            </article>
+            <article class="release-item">
+              <h3>Current data, clearly labeled</h3>
+              <p>
+                <code>get_today</code> matches recovery with the current cycle and primary sleep.
+                Pending or invalid sleep never substitutes an older score. All 16 tools return
+                validated structured results alongside compatible JSON text; missing measurements
+                stay distinct from zero.
+              </p>
+            </article>
+            <article class="release-item">
+              <h3>Choose aggregate-only access</h3>
+              <p>
+                <code>WHOOP_MCP_PRIVACY_MODE=aggregate</code> exposes five summary and analytics
+                tools, with no raw resources or prompts. Record arrays, latest observations,
+                identity fields and exact activity timestamps are omitted. Aggregates remain
+                sensitive data, not anonymous data.
+              </p>
+            </article>
+          </div>
+          <p class="release-note">
+            Local diagnostics: <code>whoop-ai-mcp doctor --json</code> checks configuration and
+            token-file metadata without calling WHOOP or launching OAuth. Available in the 0.7.0
+            release work, not the published 0.6.1 package.
+          </p>
+          <p class="release-note">
+            <a href="https://github.com/shashankswe2020-ux/whoop-mcp/blob/main/CHANGELOG.md"
+              >Changelog</a
+            >
+            ·
+            <a href="https://github.com/shashankswe2020-ux/whoop-mcp#structured-results-and-privacy"
+              >Privacy and compatibility notes</a
+            >
+          </p>
+        </section>
+
         <section class="setup" id="setup">
-          <h2 class="setup-head">Connect it in one command</h2>
+          <h2 class="setup-head">Connect the published release</h2>
           <p class="setup-sub">
-            The setup wizard writes your client config and verifies your WHOOP
-            credentials in one go. Have your WHOOP Developer App client ID and secret
-            ready from
+            These commands install the published package, currently 0.6.1. The setup wizard writes
+            or prints your client configuration; add <code>--verify</code>
+            for an explicit live authorization check. Have your WHOOP Developer App client ID and
+            secret ready from
             <a href="https://developer.whoop.com">developer.whoop.com</a>.
           </p>
           <div class="setup-grid">
@@ -681,8 +819,8 @@
               </div>
               <p>
                 Merges the <code>whoop</code> server into
-                <code>claude_desktop_config.json</code> (with a <code>.bak</code> backup),
-                then restart Claude Desktop to load it.
+                <code>claude_desktop_config.json</code> (with a <code>.bak</code> backup), then
+                restart Claude Desktop to load it.
               </p>
             </div>
 
@@ -708,9 +846,8 @@
                 </button>
               </div>
               <p>
-                Prints the equivalent <code>claude mcp add</code> command to register the
-                server with Claude Code. Add <code>--verify</code> to run the OAuth flow
-                end-to-end.
+                Prints the equivalent <code>claude mcp add</code> command to register the server
+                with Claude Code. Add <code>--verify</code> to run the OAuth flow end-to-end.
               </p>
             </div>
 
@@ -736,8 +873,8 @@
                 </button>
               </div>
               <p>
-                Prints a <code>codex mcp add</code> command that registers the server in
-                your <code>~/.codex/config.toml</code> for the OpenAI Codex CLI.
+                Prints a <code>codex mcp add</code> command that registers the server in your
+                <code>~/.codex/config.toml</code> for the OpenAI Codex CLI.
               </p>
             </div>
 
@@ -763,8 +900,8 @@
                 </button>
               </div>
               <p>
-                Prints a <code>code --add-mcp</code> command to register the server with
-                GitHub Copilot in VS Code.
+                Prints a <code>code --add-mcp</code> command to register the server with GitHub
+                Copilot in VS Code.
               </p>
             </div>
           </div>
@@ -783,13 +920,13 @@
     </div>
 
     <script>
-      document.querySelectorAll('.install').forEach((wrap) => {
-        const btn = wrap.querySelector('.copy');
+      document.querySelectorAll(".install").forEach((wrap) => {
+        const btn = wrap.querySelector(".copy");
         if (!btn) return;
         const original = btn.innerHTML;
-        btn.addEventListener('click', async () => {
+        btn.addEventListener("click", async () => {
           try {
-            await navigator.clipboard.writeText(wrap.getAttribute('data-install') || '');
+            await navigator.clipboard.writeText(wrap.getAttribute("data-install") || "");
             btn.innerHTML = '<span class="copied">Copied</span>';
             setTimeout(() => (btn.innerHTML = original), 1400);
           } catch {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -214,9 +214,14 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
 
   async function parseErrorBody(response: Response): Promise<unknown> {
     try {
-      return await response.json();
+      const rawBody = await response.text();
+      try {
+        return JSON.parse(rawBody) as unknown;
+      } catch {
+        return rawBody;
+      }
     } catch {
-      return await response.text();
+      return null;
     }
   }
 
@@ -277,6 +282,7 @@ export function createWhoopClient(options: WhoopClientOptions): WhoopClient {
         }
 
         // Retry with the new token
+        options.accessToken = newToken;
         currentToken = newToken;
         const retryResponse = await doFetch(url, newToken);
         if (retryResponse.ok) {

--- a/src/api/record-schemas.ts
+++ b/src/api/record-schemas.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+const nonnegative = z.number().finite().nonnegative();
+const percentage = nonnegative.max(100);
+export const timestampSchema = z.string().datetime({ offset: true });
+export const offsetSchema = z.string().regex(/^[+-](?:0\d|1[0-4]):[0-5]\d$/);
+const common = {
+  user_id: z.number().int(),
+  created_at: timestampSchema,
+  updated_at: timestampSchema,
+  score_state: z.enum(["SCORED", "PENDING_SCORE", "UNSCORABLE"]),
+};
+const activity = {
+  ...common,
+  start: timestampSchema,
+  end: timestampSchema,
+  timezone_offset: offsetSchema,
+};
+
+export const recoveryRecordSchema = z
+  .object({
+    ...common,
+    cycle_id: z.number().int(),
+    sleep_id: z.string().min(1),
+    score: z
+      .object({
+        user_calibrating: z.boolean(),
+        recovery_score: percentage,
+        resting_heart_rate: nonnegative,
+        hrv_rmssd_milli: nonnegative,
+        spo2_percentage: percentage.optional(),
+        skin_temp_celsius: z.number().finite().optional(),
+      })
+      .nullish(),
+  })
+  .passthrough();
+
+export const sleepRecordSchema = z
+  .object({
+    ...activity,
+    id: z.string().min(1),
+    cycle_id: z.number().int(),
+    nap: z.boolean(),
+    score: z
+      .object({
+        stage_summary: z.object({
+          total_in_bed_time_milli: nonnegative,
+          total_awake_time_milli: nonnegative,
+          total_no_data_time_milli: nonnegative,
+          total_light_sleep_time_milli: nonnegative,
+          total_slow_wave_sleep_time_milli: nonnegative,
+          total_rem_sleep_time_milli: nonnegative,
+          sleep_cycle_count: nonnegative,
+          disturbance_count: nonnegative,
+        }),
+        sleep_needed: z.object({
+          baseline_milli: nonnegative,
+          need_from_sleep_debt_milli: z.number().finite(),
+          need_from_recent_strain_milli: z.number().finite(),
+          need_from_recent_nap_milli: z.number().finite(),
+        }),
+        respiratory_rate: nonnegative.optional(),
+        sleep_performance_percentage: percentage.optional(),
+        sleep_efficiency_percentage: percentage.optional(),
+        sleep_consistency_percentage: percentage.optional(),
+      })
+      .nullish(),
+  })
+  .passthrough();
+
+export const cycleRecordSchema = z
+  .object({
+    ...activity,
+    id: z.number().int(),
+    end: timestampSchema.nullish(),
+    score: z
+      .object({
+        strain: nonnegative.max(21),
+        kilojoule: nonnegative,
+        average_heart_rate: nonnegative,
+        max_heart_rate: nonnegative,
+      })
+      .nullish(),
+  })
+  .passthrough();
+
+export const workoutRecordSchema = z
+  .object({
+    ...activity,
+    id: z.string().min(1),
+    sport_name: z.string().max(200),
+    score: z
+      .object({
+        strain: nonnegative.max(21),
+        average_heart_rate: nonnegative,
+        max_heart_rate: nonnegative,
+        kilojoule: nonnegative,
+        percent_recorded: percentage,
+        zone_durations: z.object({
+          zone_zero_milli: nonnegative,
+          zone_one_milli: nonnegative,
+          zone_two_milli: nonnegative,
+          zone_three_milli: nonnegative,
+          zone_four_milli: nonnegative,
+          zone_five_milli: nonnegative,
+        }),
+        distance_meter: z.number().finite().optional(),
+        altitude_gain_meter: z.number().finite().optional(),
+        altitude_change_meter: z.number().finite().optional(),
+      })
+      .nullish(),
+  })
+  .passthrough();

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -59,7 +59,7 @@ export interface Recovery {
   created_at: string;
   updated_at: string;
   score_state: ScoreState;
-  score?: RecoveryScore;
+  score?: RecoveryScore | null;
 }
 
 /** GET /v2/recovery — paginated */
@@ -112,7 +112,7 @@ export interface Sleep {
   nap: boolean;
   score_state: ScoreState;
   v1_id?: number;
-  score?: SleepScore;
+  score?: SleepScore | null;
 }
 
 /** GET /v2/activity/sleep — paginated */
@@ -137,10 +137,10 @@ export interface Cycle {
   created_at: string;
   updated_at: string;
   start: string;
-  end?: string;
+  end?: string | null;
   timezone_offset: string;
   score_state: ScoreState;
-  score?: CycleScore;
+  score?: CycleScore | null;
 }
 
 /** GET /v2/cycle — paginated */
@@ -185,7 +185,7 @@ export interface Workout {
   sport_name: string;
   score_state: ScoreState;
   v1_id?: number;
-  score?: WorkoutScore;
+  score?: WorkoutScore | null;
   sport_id?: number;
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,101 @@
+import { lstat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { privacyModeSchema } from "../privacy.js";
+
+export interface DoctorDependencies {
+  env: NodeJS.ProcessEnv;
+  nodeVersion: string;
+  platform: NodeJS.Platform;
+  inspectToken: () => Promise<{
+    exists: boolean;
+    regular: boolean;
+    mode: number;
+    directoryMode: number;
+  }>;
+  write: (text: string) => void;
+}
+
+async function inspectToken(): ReturnType<DoctorDependencies["inspectToken"]> {
+  const directory = join(homedir(), ".whoop-mcp");
+  const [folder, file] = await Promise.all([
+    lstat(directory),
+    lstat(join(directory, "tokens.json")),
+  ]);
+  return {
+    exists: true,
+    regular:
+      folder.isDirectory() && !folder.isSymbolicLink() && file.isFile() && !file.isSymbolicLink(),
+    mode: file.mode & 0o777,
+    directoryMode: folder.mode & 0o777,
+  };
+}
+
+export async function runDoctor(
+  args: string[],
+  dependencies: DoctorDependencies = {
+    env: process.env,
+    nodeVersion: process.versions.node,
+    platform: process.platform,
+    inspectToken,
+    write: (text) => {
+      process.stdout.write(`${text}\n`);
+    },
+  }
+): Promise<number> {
+  if (args.length > 1 || args.some((arg) => arg !== "--json")) {
+    dependencies.write("Usage: whoop-ai-mcp doctor [--json]");
+    return 2;
+  }
+  const { env } = dependencies;
+  const transport = (env.MCP_TRANSPORT ?? "stdio").trim().toLowerCase();
+  const privacy = privacyModeSchema.safeParse(env.WHOOP_MCP_PRIVACY_MODE ?? "standard");
+  const port = Number(env.MCP_PORT ?? "3000");
+  const checks = {
+    runtime: Number(dependencies.nodeVersion.split(".")[0]) >= 20,
+    credentials_configured: Boolean(env.WHOOP_CLIENT_ID?.trim() && env.WHOOP_CLIENT_SECRET?.trim()),
+    transport_configuration:
+      ["stdio", "http", "both"].includes(transport) &&
+      (transport === "stdio" ||
+        (Boolean(env.MCP_AUTH_TOKEN?.trim()) &&
+          Number.isInteger(port) &&
+          port >= 0 &&
+          port <= 65535)),
+    privacy_configuration: privacy.success,
+    private_token_file: false,
+  };
+  try {
+    const token = await dependencies.inspectToken();
+    checks.private_token_file =
+      dependencies.platform !== "win32" &&
+      token.exists &&
+      token.regular &&
+      token.mode === 0o600 &&
+      token.directoryMode === 0o700;
+  } catch {
+    checks.private_token_file = false;
+  }
+  const ready = Object.values(checks).every(Boolean);
+  const report = {
+    ready,
+    checks,
+    transport: ["stdio", "http", "both"].includes(transport) ? transport : "invalid",
+    privacy_mode: privacy.success ? privacy.data : "invalid",
+    scope_status: "unknown",
+    token_validity: "unknown",
+    next_step:
+      "Use setup --verify for explicit live authorization verification. No network requests were made.",
+  };
+  dependencies.write(
+    args.includes("--json")
+      ? JSON.stringify(report, null, 2)
+      : [
+          ready ? "Local checks passed." : "Local configuration needs attention.",
+          ...Object.entries(checks).map(
+            ([name, passed]) => `${name}: ${passed ? "pass" : "needs attention"}`
+          ),
+          report.next_step,
+        ].join("\n")
+  );
+  return ready ? 0 : 1;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { createLogger, type LogLevel, type Logger } from "./logging/logger.js";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 import { realpathSync } from "node:fs";
+import { privacyModeSchema } from "./privacy.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,6 +101,7 @@ function parseAllowedOrigins(): string[] {
 // ---------------------------------------------------------------------------
 
 export async function main(): Promise<void> {
+  const privacyMode = privacyModeSchema.parse(process.env.WHOOP_MCP_PRIVACY_MODE ?? "standard");
   // 1. Parse transport + logging configuration
   const transportMode = parseTransport();
   const logger: Logger = createLogger({
@@ -145,7 +147,7 @@ export async function main(): Promise<void> {
 
   // 5. Create the MCP server with all WHOOP tools and resources
   const disableResources = process.env.WHOOP_MCP_DISABLE_RESOURCES === "1";
-  const { server } = createWhoopServer(client, { disableResources });
+  const { server } = createWhoopServer(client, { disableResources, privacyMode });
 
   // 6. Connect transports based on MCP_TRANSPORT mode
   const httpResults: HttpServerResult[] = [];
@@ -288,7 +290,16 @@ function isMainModule(): boolean {
 if (isMainModule()) {
   const subcommand = process.argv[2];
 
-  if (subcommand === "setup") {
+  if (subcommand === "doctor") {
+    void import("./cli/doctor.js")
+      .then(async ({ runDoctor }) => {
+        process.exitCode = await runDoctor(process.argv.slice(3));
+      })
+      .catch(() => {
+        console.error("Local diagnostics failed.");
+        process.exitCode = 1;
+      });
+  } else if (subcommand === "setup") {
     // Lazy-load so the setup CLI's deps aren't pulled into the hot stdio path.
     void (async (): Promise<void> => {
       try {

--- a/src/privacy.ts
+++ b/src/privacy.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+export const privacyModeSchema = z.enum(["standard", "aggregate"]);
+export type PrivacyMode = z.infer<typeof privacyModeSchema>;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -134,9 +134,9 @@ export function registerResources(server: McpServer, client: WhoopClient): void 
               },
             ],
           };
-        } catch (error: unknown) {
-          const message = error instanceof Error ? error.message : "Unknown error";
-          console.error(`[whoop-mcp] Resource read failed for ${def.uri}: ${message}`);
+        } catch {
+          const message = "Resource unavailable. Retry later or verify authorization.";
+          console.error(`[whoop-mcp] Resource read failed for ${def.uri}`);
           return {
             contents: [
               {

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,16 @@ import { registerResources } from "./resources/index.js";
 import { registerPrompts } from "./prompts/index.js";
 import { ISO_8601_REGEX } from "./tools/date-utils.js";
 import { readFileSync } from "node:fs";
+import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { getBaselines, baselinesInputSchema } from "./tools/get-baselines.js";
+import { getSleepDebt, sleepDebtInputSchema } from "./tools/get-sleep-debt.js";
+import {
+  outputSchemas,
+  aggregateOutputSchemas,
+  privacyModeSchema,
+  projectAggregateDates,
+  type PrivacyMode,
+} from "./tools/output-contracts.js";
 
 // ---------------------------------------------------------------------------
 // Package version
@@ -97,11 +107,11 @@ const collectionInputSchema = z.object({
 // JSON response helper
 // ---------------------------------------------------------------------------
 
-function jsonContent(data: unknown): {
-  content: Array<{ type: "text"; text: string }>;
-} {
+function jsonContent(data: unknown): CallToolResult {
+  const text = JSON.stringify(data, null, 2);
   return {
-    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    content: [{ type: "text" as const, text }],
+    structuredContent: JSON.parse(text) as Record<string, unknown>,
   };
 }
 
@@ -117,16 +127,15 @@ function errorResponse(error: unknown): {
   let message: string;
 
   if (error instanceof WhoopApiError) {
-    const bodyStr = typeof error.body === "string" ? error.body : JSON.stringify(error.body);
-    message = `WHOOP API returned ${error.statusCode} ${error.statusText}: ${bodyStr}`;
+    message = `WHOOP API returned ${error.statusCode}. Retry later or verify authorization.`;
   } else if (error instanceof WhoopAuthError) {
-    message = error.message;
+    message = "WHOOP authentication failed. Run setup --verify to reconnect.";
   } else if (error instanceof WhoopNetworkError) {
-    message = error.message;
-  } else if (error instanceof Error) {
-    message = `Unexpected error: ${error.message}`;
+    message = "Network error: Unable to reach the WHOOP API. Check your internet connection.";
+  } else if (error instanceof z.ZodError || error instanceof RangeError) {
+    message = "Invalid input or data. Check the requested parameters and date range.";
   } else {
-    message = "An unexpected error occurred";
+    message = "An unexpected error occurred. Check configuration and retry.";
   }
 
   return {
@@ -136,12 +145,7 @@ function errorResponse(error: unknown): {
 }
 
 /** Wrap a tool handler with error-to-MCP-error conversion */
-async function safeTool<T>(
-  fn: () => Promise<T>
-): Promise<
-  | { content: Array<{ type: "text"; text: string }> }
-  | { isError: true; content: Array<{ type: "text"; text: string }> }
-> {
+async function safeTool<T>(fn: () => Promise<T>): Promise<CallToolResult> {
   try {
     return jsonContent(await fn());
   } catch (error: unknown) {
@@ -155,6 +159,7 @@ async function safeTool<T>(
 
 /** Options for createWhoopServer */
 export interface CreateServerOptions {
+  privacyMode?: PrivacyMode;
   /** Disable MCP resource registration (set via WHOOP_MCP_DISABLE_RESOURCES=1) */
   disableResources?: boolean;
 }
@@ -175,15 +180,47 @@ export interface WhoopServer {
  * @param options - Optional configuration (e.g., disable resources)
  */
 export function createWhoopServer(client: WhoopClient, options?: CreateServerOptions): WhoopServer {
+  const privacyMode = privacyModeSchema.parse(options?.privacyMode ?? "standard");
   const server = new McpServer({
     name: "whoop-mcp",
     version: getPackageVersion(),
   });
 
+  function registerTool<Shape extends z.ZodRawShape>(
+    name: string,
+    config: { description: string; inputSchema?: z.ZodObject<Shape>; annotations: ToolAnnotations },
+    handler: (args: z.infer<z.ZodObject<Shape>>) => Promise<CallToolResult>
+  ): void {
+    const schema = (privacyMode === "aggregate" ? aggregateOutputSchemas : outputSchemas)[name];
+    if (!schema) {
+      if (privacyMode === "aggregate") return;
+      throw new Error("Missing tool output contract.");
+    }
+    server.registerTool(
+      name,
+      { ...config, inputSchema: config.inputSchema ?? z.object({}), outputSchema: schema },
+      async (args) => {
+        const result = await handler(args as z.infer<z.ZodObject<Shape>>);
+        if (result.isError) return result;
+        const validated = schema.safeParse(result.structuredContent);
+        if (!validated.success)
+          return {
+            isError: true,
+            content: [
+              { type: "text", text: "WHOOP data did not match the expected output contract." },
+            ],
+          };
+        return jsonContent(
+          privacyMode === "aggregate" ? projectAggregateDates(validated.data) : validated.data
+        );
+      }
+    );
+  }
+
   // -------------------------------------------------------------------------
   // Tool 1: get_profile
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_profile",
     {
       description: "Get the authenticated user's basic profile — name and email.",
@@ -195,7 +232,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 2: get_body_measurement
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_body_measurement",
     {
       description: "Get the user's body measurements — height, weight, and max heart rate.",
@@ -207,7 +244,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 3: get_recovery_collection
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_recovery_collection",
     {
       description:
@@ -222,7 +259,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 4: get_sleep_collection
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_sleep_collection",
     {
       description:
@@ -237,7 +274,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 5: get_workout_collection
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_workout_collection",
     {
       description:
@@ -252,7 +289,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 6: get_cycle_collection
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_cycle_collection",
     {
       description:
@@ -267,7 +304,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 7: get_sleep_by_id
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_sleep_by_id",
     {
       description:
@@ -281,7 +318,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 8: get_workout_by_id
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_workout_by_id",
     {
       description:
@@ -295,7 +332,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 9: get_cycle_by_id
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_cycle_by_id",
     {
       description:
@@ -309,7 +346,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 10: get_weekly_summary
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_weekly_summary",
     {
       description:
@@ -330,7 +367,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 11: compare_periods
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "compare_periods",
     {
       description:
@@ -354,7 +391,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 12: get_trend
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_trend",
     {
       description:
@@ -382,7 +419,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 13: get_today
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_today",
     {
       description:
@@ -395,7 +432,7 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // Tool 14: get_calendar
   // -------------------------------------------------------------------------
-  server.registerTool(
+  registerTool(
     "get_calendar",
     {
       description:
@@ -423,14 +460,35 @@ export function createWhoopServer(client: WhoopClient, options?: CreateServerOpt
   // -------------------------------------------------------------------------
   // MCP Resources
   // -------------------------------------------------------------------------
-  if (!options?.disableResources) {
+  registerTool(
+    "get_baselines",
+    {
+      description:
+        "Personal rolling distributions for HRV, RHR, sleep and recovery. Excludes latest observations from baselines; not medical advice.",
+      inputSchema: baselinesInputSchema,
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => safeTool(() => getBaselines(client, args))
+  );
+  registerTool(
+    "get_sleep_debt",
+    {
+      description:
+        "Observed nightly sleep deficits, standing debt and local clock consistency. Deficit sum is not outstanding debt or a recovery prediction.",
+      inputSchema: sleepDebtInputSchema,
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => safeTool(() => getSleepDebt(client, args))
+  );
+
+  if (!options?.disableResources && privacyMode === "standard") {
     registerResources(server, client);
   }
 
   // -------------------------------------------------------------------------
   // MCP Prompts
   // -------------------------------------------------------------------------
-  registerPrompts(server);
+  if (privacyMode === "standard") registerPrompts(server);
 
   return { server };
 }

--- a/src/tools/analytics-utils.ts
+++ b/src/tools/analytics-utils.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+import { offsetSchema } from "../api/record-schemas.js";
+import type { Sleep } from "../api/types.js";
+import type { WhoopClient } from "../api/client.js";
+import { fetchAllPages, ABSOLUTE_MAX_RECORDS } from "../api/pagination.js";
+
+export const DISCLAIMER = "Statistical observation from your data, not medical advice.";
+export const DAY_MS = 86_400_000;
+export const HOUR_MS = 3_600_000;
+export const periodSchema = z.object({ start: z.string(), end: z.string() });
+export const sourceQualitySchema = z.object({
+  status: z.enum([
+    "available",
+    "pending",
+    "missing",
+    "stale",
+    "unscored",
+    "calibrating",
+    "invalid",
+    "fetch_failed",
+  ]),
+  fetched_at: z.string().nullable(),
+  source_updated_at: z.string().nullable(),
+  cache_status: z.enum(["hit", "miss", "unknown"]),
+  records_fetched: z.number().int().nonnegative(),
+  records_used: z.number().int().nonnegative(),
+  exclusions: z.record(z.string(), z.number().int().nonnegative()),
+  truncated: z.boolean(),
+});
+export const dataQualitySchema = z.object({
+  evaluated_at: z.string(),
+  requested_period: periodSchema,
+  observed_period: periodSchema.nullable(),
+  sources: z.record(z.string(), sourceQualitySchema),
+  method_version: z.string(),
+  limitations: z.array(z.string()),
+});
+export type SourceQuality = z.infer<typeof sourceQualitySchema>;
+export type DataQuality = z.infer<typeof dataQualitySchema>;
+
+export function sourceQuality(count = 0, truncated = false): SourceQuality {
+  return {
+    status: "missing",
+    fetched_at: null,
+    source_updated_at: null,
+    cache_status: "unknown",
+    records_fetched: count,
+    records_used: 0,
+    exclusions: {},
+    truncated,
+  };
+}
+
+export function exclude(quality: SourceQuality, reason: string): void {
+  quality.exclusions[reason] = (quality.exclusions[reason] ?? 0) + 1;
+}
+
+export function localTime(timestamp: string, offset: string): Date {
+  offsetSchema.parse(offset);
+  const minutes =
+    (Number(offset.slice(1, 3)) * 60 + Number(offset.slice(4, 6))) * (offset[0] === "-" ? -1 : 1);
+  return new Date(Date.parse(timestamp) + minutes * 60_000);
+}
+
+export function localDay(timestamp: string, offset: string): string {
+  return localTime(timestamp, offset).toISOString().slice(0, 10);
+}
+
+export function asleepHours(sleep: Sleep): number {
+  const stages = sleep.score!.stage_summary;
+  return (
+    (stages.total_light_sleep_time_milli +
+      stages.total_slow_wave_sleep_time_milli +
+      stages.total_rem_sleep_time_milli) /
+    HOUR_MS
+  );
+}
+
+export function observedPeriod(timestamps: string[]): { start: string; end: string } | null {
+  const sorted = timestamps
+    .filter((value) => Number.isFinite(Date.parse(value)))
+    .sort((left, right) => Date.parse(left) - Date.parse(right));
+  return sorted.length ? { start: sorted[0]!, end: sorted[sorted.length - 1]! } : null;
+}
+
+export function parseRecords<T>(
+  records: unknown[],
+  schema: z.ZodType<T>,
+  quality: SourceQuality
+): T[] {
+  const parsed: T[] = [];
+  for (const record of records) {
+    const result = schema.safeParse(record);
+    if (result.success) parsed.push(result.data);
+    else exclude(quality, "invalid");
+  }
+  if (!parsed.length && records.length) quality.status = "invalid";
+  return parsed;
+}
+
+export async function loadAnalyticsSource<T>(
+  client: WhoopClient,
+  endpoint: string,
+  period: { start: string; end: string },
+  schema: z.ZodType<T>
+): Promise<{ records: T[]; quality: SourceQuality }> {
+  const query = new URLSearchParams({ ...period, limit: "25" });
+  const pageSchema = z.object({
+    records: z.array(z.unknown()),
+    next_token: z.string().max(4096).optional(),
+  });
+  const validatedClient: WhoopClient = {
+    get: async <Result>(path: string): Promise<Result> =>
+      pageSchema.parse(await client.get<unknown>(path)) as Result,
+  };
+  try {
+    const result = await fetchAllPages<unknown>(validatedClient, `${endpoint}?${query}`, {
+      maxRecords: ABSOLUTE_MAX_RECORDS,
+    });
+    const quality = sourceQuality(result.records.length, result.truncated);
+    const records = parseRecords(result.records, schema, quality);
+    return { records, quality };
+  } catch (error: unknown) {
+    return {
+      records: [],
+      quality: {
+        ...sourceQuality(),
+        status: error instanceof z.ZodError ? "invalid" : "fetch_failed",
+      },
+    };
+  }
+}
+
+export function mainSleeps(
+  records: Sleep[],
+  period: { start: string; end: string },
+  quality: SourceQuality
+): Sleep[] {
+  const selected = new Map<string, Sleep>();
+  for (const record of records) {
+    const duration = Date.parse(record.end) - Date.parse(record.start);
+    if (
+      duration <= 0 ||
+      Date.parse(record.end) < Date.parse(period.start) ||
+      Date.parse(record.end) >= Date.parse(period.end)
+    ) {
+      exclude(quality, "outside_window_or_invalid_duration");
+      continue;
+    }
+    if (record.nap) {
+      exclude(quality, "nap");
+      continue;
+    }
+    if (record.score_state !== "SCORED" || !record.score) {
+      exclude(quality, record.score_state === "PENDING_SCORE" ? "pending" : "unscored");
+      continue;
+    }
+    const key = localDay(record.end, record.timezone_offset);
+    const previous = selected.get(key);
+    if (previous) {
+      exclude(quality, "duplicate_day");
+      const previousDuration = Date.parse(previous.end) - Date.parse(previous.start);
+      if (
+        duration < previousDuration ||
+        (duration === previousDuration &&
+          (Date.parse(record.end) < Date.parse(previous.end) ||
+            (record.end === previous.end && record.id >= previous.id)))
+      )
+        continue;
+    }
+    selected.set(key, record);
+  }
+  return [...selected.values()].sort((left, right) => Date.parse(right.end) - Date.parse(left.end));
+}
+
+export function finishQuality(quality: SourceQuality, records: { updated_at: string }[]): void {
+  quality.records_used = records.length;
+  quality.source_updated_at =
+    observedPeriod(records.map((record) => record.updated_at))?.end ?? null;
+  if (records.length) quality.status = "available";
+  else if (quality.status !== "fetch_failed" && quality.status !== "invalid") {
+    quality.status = quality.exclusions.pending
+      ? "pending"
+      : quality.exclusions.calibrating
+        ? "calibrating"
+        : quality.exclusions.unscored
+          ? "unscored"
+          : "missing";
+  }
+}

--- a/src/tools/date-utils.ts
+++ b/src/tools/date-utils.ts
@@ -128,7 +128,7 @@ function lastDayOfMonthUTC(year: number, month: number): Date {
  *
  * @throws InvalidDateExpression for unrecognized or invalid expressions
  */
-export function resolveDateExpression(expression: string): DateRange {
+export function resolveDateExpression(expression: string, now: Date = new Date()): DateRange {
   const trimmed = expression.trim();
 
   if (trimmed.length === 0) {
@@ -141,7 +141,6 @@ export function resolveDateExpression(expression: string): DateRange {
   }
 
   const lower = trimmed.toLowerCase();
-  const now = new Date();
 
   // "today"
   if (lower === "today") {

--- a/src/tools/get-baselines.ts
+++ b/src/tools/get-baselines.ts
@@ -1,0 +1,225 @@
+import { z } from "zod";
+import type { WhoopClient } from "../api/client.js";
+import { WhoopNetworkError } from "../api/client.js";
+import { ENDPOINT_CYCLE, ENDPOINT_RECOVERY, ENDPOINT_SLEEP } from "../api/endpoints.js";
+import {
+  cycleRecordSchema,
+  recoveryRecordSchema,
+  sleepRecordSchema,
+} from "../api/record-schemas.js";
+import {
+  dataQualitySchema,
+  DAY_MS,
+  DISCLAIMER,
+  exclude,
+  finishQuality,
+  loadAnalyticsSource,
+  localDay,
+  mainSleeps,
+  observedPeriod,
+  periodSchema,
+  asleepHours,
+} from "./analytics-utils.js";
+import { mean, median, percentile, standardDeviation } from "./stats-utils.js";
+
+export const baselinesInputSchema = z.object({
+  baseline_days: z.number().int().min(14).max(180).optional(),
+});
+const metricNameSchema = z.enum([
+  "hrv",
+  "rhr",
+  "respiratory_rate",
+  "sleep_hours",
+  "recovery_score",
+]);
+const bandSchema = z.object({
+  sample_size: z.number().int(),
+  mean: z.number(),
+  median: z.number(),
+  std_dev: z.number(),
+  p10: z.number(),
+  p25: z.number(),
+  p50: z.number(),
+  p75: z.number(),
+  p90: z.number(),
+  latest: z.number().nullable(),
+  latest_percentile: z.number().nullable(),
+  constant_baseline: z.boolean(),
+});
+export const baselinesOutputSchema = z.object({
+  period: periodSchema.nullable(),
+  metrics: z.record(metricNameSchema, bandSchema.nullable()),
+  metric_status: z.record(
+    metricNameSchema,
+    z.object({
+      status: z.enum(["available", "insufficient_data"]),
+      sample_size: z.number().int(),
+      unit: z.string(),
+    })
+  ),
+  data_quality: dataQualitySchema,
+  truncated: z.boolean(),
+  disclaimer: z.string(),
+});
+export type BaselineReport = z.infer<typeof baselinesOutputSchema>;
+type Metric = z.infer<typeof metricNameSchema>;
+type Observation = { value: number; timestamp: string; offset: string };
+
+export async function getBaselines(
+  client: WhoopClient,
+  params: z.infer<typeof baselinesInputSchema> = {},
+  now: Date = new Date()
+): Promise<BaselineReport> {
+  const { baseline_days = 30 } = baselinesInputSchema.parse(params);
+  const period = {
+    start: new Date(now.getTime() - baseline_days * DAY_MS).toISOString(),
+    end: now.toISOString(),
+  };
+  const [recovery, sleep, cycle] = await Promise.all([
+    loadAnalyticsSource(client, ENDPOINT_RECOVERY, period, recoveryRecordSchema),
+    loadAnalyticsSource(client, ENDPOINT_SLEEP, period, sleepRecordSchema),
+    loadAnalyticsSource(client, ENDPOINT_CYCLE, period, cycleRecordSchema),
+  ]);
+  if ([recovery, sleep, cycle].every((source) => source.quality.status === "fetch_failed"))
+    throw new WhoopNetworkError("Baseline sources unavailable");
+  const observations: Record<Metric, Observation[]> = {
+    hrv: [],
+    rhr: [],
+    respiratory_rate: [],
+    sleep_hours: [],
+    recovery_score: [],
+  };
+  const cycles = new Map(cycle.records.map((record) => [`${record.user_id}:${record.id}`, record]));
+  const usedRecoveries: typeof recovery.records = [];
+  const usedCycles: typeof cycle.records = [];
+  const seenCycles = new Set<string>();
+  for (const record of recovery.records) {
+    if (record.score_state !== "SCORED" || !record.score) {
+      exclude(recovery.quality, record.score_state === "PENDING_SCORE" ? "pending" : "unscored");
+      continue;
+    }
+    if (record.score.user_calibrating) {
+      exclude(recovery.quality, "calibrating");
+      continue;
+    }
+    const key = `${record.user_id}:${record.cycle_id}`;
+    const context = cycles.get(key);
+    if (!context) {
+      exclude(recovery.quality, "missing_join");
+      continue;
+    }
+    if (
+      Date.parse(context.start) < Date.parse(period.start) ||
+      Date.parse(context.start) >= now.getTime()
+    ) {
+      exclude(recovery.quality, "outside_window");
+      continue;
+    }
+    if (seenCycles.has(key)) {
+      exclude(recovery.quality, "duplicate_cycle");
+      continue;
+    }
+    seenCycles.add(key);
+    usedRecoveries.push(record);
+    usedCycles.push(context);
+    for (const [metric, value] of [
+      ["hrv", record.score.hrv_rmssd_milli],
+      ["rhr", record.score.resting_heart_rate],
+      ["recovery_score", record.score.recovery_score],
+    ] as const) {
+      observations[metric].push({
+        value,
+        timestamp: context.start,
+        offset: context.timezone_offset,
+      });
+    }
+  }
+  const nights = mainSleeps(sleep.records, period, sleep.quality);
+  for (const night of nights) {
+    observations.sleep_hours.push({
+      value: asleepHours(night),
+      timestamp: night.end,
+      offset: night.timezone_offset,
+    });
+    if (night.score?.respiratory_rate !== undefined)
+      observations.respiratory_rate.push({
+        value: night.score.respiratory_rate,
+        timestamp: night.end,
+        offset: night.timezone_offset,
+      });
+  }
+  const metrics = {} as BaselineReport["metrics"];
+  const metricStatus = {} as BaselineReport["metric_status"];
+  const usedTimestamps: string[] = [];
+  const units: Record<Metric, string> = {
+    hrv: "ms",
+    rhr: "bpm",
+    recovery_score: "%",
+    respiratory_rate: "breaths/min",
+    sleep_hours: "hours",
+  };
+  for (const metric of metricNameSchema.options) {
+    const sorted = observations[metric].sort(
+      (left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp)
+    );
+    const latest = sorted[0];
+    const historical = sorted
+      .slice(1)
+      .filter(
+        (item) => localDay(item.timestamp, item.offset) !== localDay(now.toISOString(), item.offset)
+      );
+    const values = historical.map((item) => item.value);
+    usedTimestamps.push(...historical.map((item) => item.timestamp));
+    metricStatus[metric] = {
+      status: values.length >= 14 ? "available" : "insufficient_data",
+      sample_size: values.length,
+      unit: units[metric],
+    };
+    metrics[metric] =
+      values.length < 14
+        ? null
+        : {
+            sample_size: values.length,
+            mean: mean(values),
+            median: median(values),
+            std_dev: standardDeviation(values),
+            p10: percentile(values, 10),
+            p25: percentile(values, 25),
+            p50: percentile(values, 50),
+            p75: percentile(values, 75),
+            p90: percentile(values, 90),
+            latest: latest?.value ?? null,
+            latest_percentile: latest
+              ? (100 *
+                  (values.filter((value) => value < latest.value).length +
+                    0.5 * values.filter((value) => value === latest.value).length)) /
+                values.length
+              : null,
+            constant_baseline: standardDeviation(values) === 0,
+          };
+  }
+  finishQuality(recovery.quality, usedRecoveries);
+  finishQuality(sleep.quality, nights);
+  finishQuality(cycle.quality, usedCycles);
+  const observed = observedPeriod(usedTimestamps);
+  const truncated = [recovery, sleep, cycle].some((source) => source.quality.truncated);
+  return {
+    period: observed,
+    metrics,
+    metric_status: metricStatus,
+    truncated,
+    disclaimer: DISCLAIMER,
+    data_quality: {
+      evaluated_at: now.toISOString(),
+      requested_period: period,
+      observed_period: observed,
+      sources: { recovery: recovery.quality, sleep: sleep.quality, cycle: cycle.quality },
+      method_version: "baselines-1",
+      limitations: [
+        "Descriptive personal distributions, not population norms or diagnosis.",
+        "Latest observation and current local day are excluded from each baseline.",
+        ...(truncated ? ["Partial history: upstream pagination limit reached."] : []),
+      ],
+    },
+  };
+}

--- a/src/tools/get-sleep-debt.ts
+++ b/src/tools/get-sleep-debt.ts
@@ -1,0 +1,155 @@
+import { z } from "zod";
+import type { WhoopClient } from "../api/client.js";
+import { WhoopNetworkError } from "../api/client.js";
+import { ENDPOINT_SLEEP } from "../api/endpoints.js";
+import { sleepRecordSchema } from "../api/record-schemas.js";
+import { resolveDateExpression } from "./date-utils.js";
+import { circularStats, mean } from "./stats-utils.js";
+import {
+  asleepHours,
+  dataQualitySchema,
+  DAY_MS,
+  DISCLAIMER,
+  HOUR_MS,
+  loadAnalyticsSource,
+  mainSleeps,
+  localDay,
+  localTime,
+  observedPeriod,
+  periodSchema,
+  finishQuality,
+  exclude,
+} from "./analytics-utils.js";
+
+export const sleepDebtInputSchema = z.object({
+  days: z.number().int().min(3).max(90).optional(),
+  start: z.string().max(100).optional(),
+});
+const nightSchema = z.object({
+  date: z.string(),
+  needed_hours: z.number(),
+  achieved_hours: z.number(),
+  debt_hours: z.number(),
+});
+export const sleepDebtOutputSchema = z.object({
+  period: periodSchema,
+  nights_analyzed: z.number().int(),
+  status: z.enum(["available", "insufficient_data"]),
+  total_debt_hours: z.number().nullable(),
+  avg_nightly_debt_hours: z.number().nullable(),
+  standing_debt_hours: z.number().nullable(),
+  standing_debt_date: z.string().nullable(),
+  consistency: z.object({
+    bedtime_std_dev_minutes: z.number().nullable(),
+    waketime_std_dev_minutes: z.number().nullable(),
+    social_jetlag_minutes: z.number().nullable(),
+  }),
+  nights: z.array(nightSchema).max(30),
+  output_capped: z.boolean(),
+  truncated: z.boolean(),
+  summary: z.string(),
+  disclaimer: z.string(),
+  data_quality: dataQualitySchema,
+});
+export type SleepDebtReport = z.infer<typeof sleepDebtOutputSchema>;
+
+export async function getSleepDebt(
+  client: WhoopClient,
+  params: z.infer<typeof sleepDebtInputSchema> = {},
+  now: Date = new Date()
+): Promise<SleepDebtReport> {
+  const { days = 14, start } = sleepDebtInputSchema.parse(params);
+  const startTime = start
+    ? Date.parse(resolveDateExpression(start, now).start)
+    : now.getTime() - days * DAY_MS;
+  const endTime = Math.min(startTime + days * DAY_MS, now.getTime());
+  if (!Number.isFinite(startTime) || startTime >= endTime)
+    throw new RangeError("Sleep window must begin before the evaluation time.");
+  const period = { start: new Date(startTime).toISOString(), end: new Date(endTime).toISOString() };
+  const source = await loadAnalyticsSource(client, ENDPOINT_SLEEP, period, sleepRecordSchema);
+  if (source.quality.status === "fetch_failed")
+    throw new WhoopNetworkError("Sleep source unavailable");
+  const selected = mainSleeps(source.records, period, source.quality).filter((night) => {
+    const need = night.score!.sleep_needed;
+    if (
+      need.baseline_milli + need.need_from_recent_strain_milli + need.need_from_recent_nap_milli <
+      0
+    ) {
+      exclude(source.quality, "invalid_need");
+      return false;
+    }
+    return true;
+  });
+  const nights = selected.map((night) => {
+    const need = night.score!.sleep_needed;
+    const needed =
+      (need.baseline_milli + need.need_from_recent_strain_milli + need.need_from_recent_nap_milli) /
+      HOUR_MS;
+    const achieved = asleepHours(night);
+    return {
+      date: localDay(night.end, night.timezone_offset),
+      needed_hours: needed,
+      achieved_hours: achieved,
+      debt_hours: Math.max(0, needed - achieved),
+    };
+  });
+  const bedtimes: number[] = [];
+  const waketimes: number[] = [];
+  const weekdays: number[] = [];
+  const weekends: number[] = [];
+  for (const night of selected) {
+    const bedtime = localTime(night.start, night.timezone_offset);
+    const wake = localTime(night.end, night.timezone_offset);
+    const bedMinutes =
+      bedtime.getUTCHours() * 60 + bedtime.getUTCMinutes() + bedtime.getUTCSeconds() / 60;
+    bedtimes.push(bedMinutes);
+    waketimes.push(wake.getUTCHours() * 60 + wake.getUTCMinutes() + wake.getUTCSeconds() / 60);
+    const midpoint =
+      (bedMinutes + (Date.parse(night.end) - Date.parse(night.start)) / 120_000) % 1440;
+    (wake.getUTCDay() === 0 || wake.getUTCDay() === 6 ? weekends : weekdays).push(midpoint);
+  }
+  const weekdayMean = circularStats(weekdays).mean;
+  const weekendMean = circularStats(weekends).mean;
+  const midpointDistance =
+    weekdayMean === null || weekendMean === null ? null : Math.abs(weekdayMean - weekendMean);
+  const sufficient = nights.length >= 3;
+  finishQuality(source.quality, selected);
+  const observed = observedPeriod(selected.map((night) => night.end));
+  return {
+    period,
+    nights_analyzed: nights.length,
+    status: sufficient ? "available" : "insufficient_data",
+    total_debt_hours: sufficient
+      ? nights.reduce((total, night) => total + night.debt_hours, 0)
+      : null,
+    avg_nightly_debt_hours: sufficient ? mean(nights.map((night) => night.debt_hours)) : null,
+    standing_debt_hours: selected[0]
+      ? selected[0].score!.sleep_needed.need_from_sleep_debt_milli / HOUR_MS
+      : null,
+    standing_debt_date: nights[0]?.date ?? null,
+    consistency: {
+      bedtime_std_dev_minutes: sufficient ? circularStats(bedtimes).sd : null,
+      waketime_std_dev_minutes: sufficient ? circularStats(waketimes).sd : null,
+      social_jetlag_minutes:
+        sufficient && midpointDistance !== null
+          ? Math.min(midpointDistance, 1440 - midpointDistance)
+          : null,
+    },
+    nights: nights.slice(0, 30),
+    output_capped: nights.length > 30,
+    truncated: source.quality.truncated,
+    summary: `${sufficient ? "Sum of observed nightly deficits, not outstanding debt." : "Insufficient data: at least three scored main sleeps are required."} Social jetlag is a circular midpoint heuristic.${source.quality.truncated ? " Partial history: pagination limit reached." : ""}`,
+    disclaimer: DISCLAIMER,
+    data_quality: {
+      evaluated_at: now.toISOString(),
+      requested_period: period,
+      observed_period: observed,
+      sources: { sleep: source.quality },
+      method_version: "sleep-debt-1",
+      limitations: [
+        "One recorded offset cannot reconstruct within-sleep DST changes.",
+        "Deficit totals do not predict recovery or prescribe repayment.",
+      ],
+    },
+  };
+}

--- a/src/tools/get-today.ts
+++ b/src/tools/get-today.ts
@@ -20,6 +20,23 @@ import {
   ENDPOINT_CYCLE,
 } from "../api/endpoints.js";
 import { DYNAMIC_TTL_MS, CYCLE_TTL_MS } from "../resources/index.js";
+import { WhoopNetworkError } from "../api/client.js";
+import {
+  cycleRecordSchema,
+  recoveryRecordSchema,
+  sleepRecordSchema,
+  workoutRecordSchema,
+} from "../api/record-schemas.js";
+import {
+  asleepHours,
+  DAY_MS,
+  localDay,
+  observedPeriod,
+  parseRecords,
+  sourceQuality,
+  type DataQuality,
+  type SourceQuality,
+} from "./analytics-utils.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,18 +52,22 @@ export interface TodayRecovery {
 
 export interface TodaySleep {
   total_hours: number;
+  time_in_bed_hours: number;
+  asleep_hours: number;
   rem_hours: number;
   deep_hours: number;
   light_hours: number;
   awake_hours: number;
-  performance_pct: number;
-  efficiency_pct: number;
+  performance_pct: number | null;
+  efficiency_pct: number | null;
   respiratory_rate: number | null;
 }
 
 export interface TodayLastWorkout {
   sport_name: string;
   strain: number;
+  occurred_at: string;
+  percent_recorded: number;
 }
 
 export interface TodayStrain {
@@ -61,6 +82,7 @@ export interface TodaySnapshot {
   sleep: TodaySleep | null;
   strain: TodayStrain | null;
   summary: string;
+  data_quality: DataQuality;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +109,7 @@ function buildSummary(snapshot: {
   }
 
   if (snapshot.sleep) {
-    parts.push(`${snapshot.sleep.total_hours}h sleep`);
+    parts.push(`${snapshot.sleep.asleep_hours}h sleep`);
   }
 
   if (snapshot.strain) {
@@ -116,18 +138,21 @@ function buildSummary(snapshot: {
  * @returns Today's snapshot with recovery, sleep, strain, and summary
  * @throws Error if all API calls fail
  */
-export async function getToday(client: WhoopClient): Promise<TodaySnapshot> {
+export async function getToday(
+  client: WhoopClient,
+  now: Date = new Date()
+): Promise<TodaySnapshot> {
   const [recoveryResult, sleepResult, cycleResult, workoutResult] = await Promise.allSettled([
-    client.get<RecoveryCollection>(`${ENDPOINT_RECOVERY}?limit=1`, {
+    client.get<RecoveryCollection>(`${ENDPOINT_RECOVERY}?limit=25`, {
       cache: true,
       ttlMs: DYNAMIC_TTL_MS,
     }),
-    client.get<SleepCollection>(`${ENDPOINT_SLEEP}?limit=1`, {
+    client.get<SleepCollection>(`${ENDPOINT_SLEEP}?limit=25`, {
       cache: true,
       ttlMs: DYNAMIC_TTL_MS,
     }),
-    client.get<CycleCollection>(`${ENDPOINT_CYCLE}?limit=1`, { cache: true, ttlMs: CYCLE_TTL_MS }),
-    client.get<WorkoutCollection>(`${ENDPOINT_WORKOUT}?limit=1`, {
+    client.get<CycleCollection>(`${ENDPOINT_CYCLE}?limit=25`, { cache: true, ttlMs: CYCLE_TTL_MS }),
+    client.get<WorkoutCollection>(`${ENDPOINT_WORKOUT}?limit=25`, {
       cache: true,
       ttlMs: DYNAMIC_TTL_MS,
     }),
@@ -138,13 +163,122 @@ export async function getToday(client: WhoopClient): Promise<TodaySnapshot> {
   const allPrimaryFailed = primaryResults.every((r) => r.status === "rejected");
 
   if (allPrimaryFailed) {
-    throw new Error("All API calls failed. Unable to retrieve today's health snapshot.");
+    throw new WhoopNetworkError(
+      "All API calls failed. Unable to retrieve today's health snapshot."
+    );
   }
+
+  function unpack<T>(result: PromiseSettledResult<{ records: T[]; next_token?: string }>): {
+    records: T[];
+    quality: SourceQuality;
+  } {
+    if (result.status === "rejected")
+      return { records: [], quality: { ...sourceQuality(), status: "fetch_failed" } };
+    if (!Array.isArray(result.value?.records))
+      return { records: [], quality: { ...sourceQuality(), status: "invalid" } };
+    return {
+      records: result.value.records.slice(0, 25),
+      quality: sourceQuality(
+        result.value.records.length,
+        Boolean(result.value.next_token) || result.value.records.length > 25
+      ),
+    };
+  }
+  const recoveryData = unpack(recoveryResult);
+  const sleepData = unpack(sleepResult);
+  const cycleData = unpack(cycleResult);
+  const workoutData = unpack(workoutResult);
+  const cycles = parseRecords(
+    cycleData.records,
+    cycleRecordSchema.omit({ score: true }),
+    cycleData.quality
+  )
+    .filter((record) => Date.parse(record.start) <= now.getTime())
+    .sort((left, right) => Date.parse(right.start) - Date.parse(left.start));
+  const cycleCandidate = cycles.find(
+    (record) =>
+      localDay(record.start, record.timezone_offset) ===
+      localDay(now.toISOString(), record.timezone_offset)
+  );
+  const cycle = parseRecords(
+    cycleCandidate ? [cycleCandidate] : [],
+    cycleRecordSchema,
+    cycleData.quality
+  )[0];
+  if (!cycleCandidate && cycles.length) cycleData.quality.status = "stale";
+  const sleeps = parseRecords(
+    sleepData.records,
+    sleepRecordSchema.omit({ score: true }),
+    sleepData.quality
+  )
+    .filter(
+      (record) =>
+        !record.nap &&
+        Date.parse(record.end) <= now.getTime() &&
+        Date.parse(record.end) > Date.parse(record.start)
+    )
+    .sort((left, right) => Date.parse(right.end) - Date.parse(left.end));
+  const primarySleep = sleeps[0];
+  const sleepCandidate =
+    primarySleep &&
+    localDay(primarySleep.end, primarySleep.timezone_offset) ===
+      localDay(now.toISOString(), primarySleep.timezone_offset)
+      ? primarySleep
+      : undefined;
+  const currentSleep = parseRecords(
+    sleepCandidate ? [sleepCandidate] : [],
+    sleepRecordSchema,
+    sleepData.quality
+  )[0];
+  if (primarySleep && !sleepCandidate) sleepData.quality.status = "stale";
+  const recoveries = parseRecords(recoveryData.records, recoveryRecordSchema, recoveryData.quality);
+  const recoveryRecord =
+    cycle && currentSleep && currentSleep.cycle_id === cycle.id
+      ? recoveries.find(
+          (record) =>
+            record.cycle_id === cycle.id &&
+            record.sleep_id === currentSleep.id &&
+            record.user_id === cycle.user_id &&
+            record.user_id === currentSleep.user_id
+        )
+      : undefined;
+  const workouts = parseRecords(workoutData.records, workoutRecordSchema, workoutData.quality)
+    .filter(
+      (record) =>
+        Date.parse(record.end) <= now.getTime() && Date.parse(record.end) > Date.parse(record.start)
+    )
+    .sort((left, right) => Date.parse(right.start) - Date.parse(left.start));
+  function mark(
+    record: { score_state: string; score?: unknown; updated_at: string } | undefined,
+    quality: SourceQuality
+  ): boolean {
+    if (!record) return false;
+    quality.source_updated_at = record.updated_at;
+    quality.status =
+      record.score_state === "PENDING_SCORE"
+        ? "pending"
+        : record.score_state !== "SCORED"
+          ? "unscored"
+          : record.score
+            ? "available"
+            : "invalid";
+    quality.records_used = quality.status === "available" ? 1 : 0;
+    return quality.status === "available";
+  }
+  const sleepAvailable = mark(currentSleep, sleepData.quality);
+  const cycleAvailable = mark(cycle, cycleData.quality);
+  const recoveryAvailable = mark(recoveryRecord, recoveryData.quality);
+  if (!sleepAvailable && recoveryAvailable) {
+    recoveryData.quality.status = sleepData.quality.status;
+    recoveryData.quality.records_used = 0;
+  }
+  if (recoveryRecord?.score?.user_calibrating) recoveryData.quality.status = "calibrating";
+  const workoutAvailable = mark(workouts[0], workoutData.quality);
 
   // Parse recovery
   let recovery: TodayRecovery | null = null;
-  if (recoveryResult.status === "fulfilled") {
-    const record = recoveryResult.value.records[0];
+  if (recoveryAvailable && sleepAvailable) {
+    const record = recoveryRecord;
     if (record?.score) {
       recovery = {
         score: record.score.recovery_score,
@@ -158,18 +292,20 @@ export async function getToday(client: WhoopClient): Promise<TodaySnapshot> {
 
   // Parse sleep
   let sleep: TodaySleep | null = null;
-  if (sleepResult.status === "fulfilled") {
-    const record = sleepResult.value.records[0];
-    if (record?.score) {
+  if (sleepAvailable) {
+    const record = currentSleep;
+    if (record?.score_state === "SCORED" && record.score) {
       const stages = record.score.stage_summary;
       sleep = {
         total_hours: milliToHours(stages.total_in_bed_time_milli),
+        time_in_bed_hours: milliToHours(stages.total_in_bed_time_milli),
+        asleep_hours: Math.round(asleepHours(record) * 10) / 10,
         rem_hours: milliToHours(stages.total_rem_sleep_time_milli),
         deep_hours: milliToHours(stages.total_slow_wave_sleep_time_milli),
         light_hours: milliToHours(stages.total_light_sleep_time_milli),
         awake_hours: milliToHours(stages.total_awake_time_milli),
-        performance_pct: record.score.sleep_performance_percentage ?? 0,
-        efficiency_pct: record.score.sleep_efficiency_percentage ?? 0,
+        performance_pct: record.score.sleep_performance_percentage ?? null,
+        efficiency_pct: record.score.sleep_efficiency_percentage ?? null,
         respiratory_rate: record.score.respiratory_rate ?? null,
       };
     }
@@ -177,17 +313,19 @@ export async function getToday(client: WhoopClient): Promise<TodaySnapshot> {
 
   // Parse strain (cycle)
   let strain: TodayStrain | null = null;
-  if (cycleResult.status === "fulfilled") {
-    const record = cycleResult.value.records[0];
+  if (cycleAvailable) {
+    const record = cycle;
     if (record?.score) {
       // Parse last workout
       let lastWorkout: TodayLastWorkout | null = null;
-      if (workoutResult.status === "fulfilled") {
-        const workout = workoutResult.value.records[0];
+      if (workoutAvailable) {
+        const workout = workouts[0];
         if (workout?.score) {
           lastWorkout = {
             sport_name: workout.sport_name,
             strain: workout.score.strain,
+            occurred_at: workout.start,
+            percent_recorded: workout.score.percent_recorded,
           };
         }
       }
@@ -201,12 +339,39 @@ export async function getToday(client: WhoopClient): Promise<TodaySnapshot> {
   }
 
   const snapshot: TodaySnapshot = {
-    timestamp: new Date().toISOString(),
+    timestamp: now.toISOString(),
     recovery,
     sleep,
     strain,
     summary: buildSummary({ recovery, sleep, strain }),
+    data_quality: {
+      evaluated_at: now.toISOString(),
+      requested_period: {
+        start: new Date(now.getTime() - DAY_MS).toISOString(),
+        end: now.toISOString(),
+      },
+      observed_period: observedPeriod([
+        ...(sleep ? [currentSleep!.end] : []),
+        ...(strain ? [cycle!.start] : []),
+      ]),
+      sources: {
+        recovery: recoveryData.quality,
+        sleep: sleepData.quality,
+        cycle: cycleData.quality,
+        workout: workoutData.quality,
+      },
+      method_version: "today-2",
+      limitations: [
+        "Recorded offsets define local days; latest workout may be historical.",
+        "Fetch time and cache status are not available from the client.",
+      ],
+    },
   };
+
+  const unavailable = Object.entries(snapshot.data_quality.sources)
+    .filter(([, quality]) => quality.status !== "available")
+    .map(([name, quality]) => `${name}: ${quality.status}`);
+  if (unavailable.length) snapshot.summary += `. ${unavailable.join(", ")}`;
 
   return snapshot;
 }

--- a/src/tools/output-contracts.ts
+++ b/src/tools/output-contracts.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+import {
+  cycleRecordSchema,
+  recoveryRecordSchema,
+  sleepRecordSchema,
+  workoutRecordSchema,
+} from "../api/record-schemas.js";
+import { dataQualitySchema, periodSchema } from "./analytics-utils.js";
+import { baselinesOutputSchema } from "./get-baselines.js";
+import { sleepDebtOutputSchema } from "./get-sleep-debt.js";
+
+export { privacyModeSchema, type PrivacyMode } from "../privacy.js";
+const number = z.number().finite();
+const nullable = number.nullable();
+const period = periodSchema.extend({ days: number });
+const direction = z.enum(["improving", "declining", "stable"]);
+const collection = <Schema extends z.ZodType>(
+  record: Schema
+): z.ZodObject<{ records: z.ZodArray<Schema>; next_token: z.ZodOptional<z.ZodString> }> =>
+  z.object({ records: z.array(record), next_token: z.string().optional() });
+const weekly = z.object({
+  week_start: z.string(),
+  week_end: z.string(),
+  recovery: z.object({
+    average_score: number,
+    min_score: number,
+    max_score: number,
+    average_hrv: number,
+    average_rhr: number,
+    trend: direction,
+  }),
+  sleep: z.object({
+    average_duration_hours: number,
+    average_performance_pct: number,
+    average_efficiency_pct: number,
+  }),
+  workouts: z.object({
+    count: number,
+    total_strain: number,
+    total_calories_kj: number,
+    sport_breakdown: z.record(z.string(), number),
+  }),
+  strain: z.object({ average_daily_strain: number, max_daily_strain: number }),
+  warnings: z.array(z.string()).optional(),
+});
+const comparisonMetric = z.object({
+  period_a_avg: number,
+  period_b_avg: number,
+  change_pct: number,
+  direction: z.enum(["improved", "declined", "unchanged"]),
+});
+const comparison = z.object({
+  period_a: period,
+  period_b: period,
+  recovery: comparisonMetric,
+  sleep: z.object({
+    period_a_avg_hours: number,
+    period_b_avg_hours: number,
+    change_pct: number,
+    direction: z.enum(["improved", "declined", "unchanged"]),
+  }),
+  strain: comparisonMetric.extend({ direction: z.enum(["increased", "decreased", "unchanged"]) }),
+});
+const trend = z.object({
+  metric: z.string(),
+  period,
+  values: z.array(number),
+  statistics: z.object({ mean: number, median: number, std_dev: number, min: number, max: number }),
+  trend: z.object({ direction, slope: number, confidence: z.enum(["high", "medium", "low"]) }),
+  anomalies: z.array(z.object({ date: z.string(), value: number, deviation_from_mean: number })),
+});
+const today = z.object({
+  timestamp: z.string(),
+  recovery: z
+    .object({
+      score: number,
+      hrv_rmssd_milli: number,
+      resting_heart_rate: number,
+      spo2_pct: nullable,
+      skin_temp_celsius: nullable,
+    })
+    .nullable(),
+  sleep: z
+    .object({
+      total_hours: number,
+      time_in_bed_hours: number,
+      asleep_hours: number,
+      rem_hours: number,
+      deep_hours: number,
+      light_hours: number,
+      awake_hours: number,
+      performance_pct: nullable,
+      efficiency_pct: nullable,
+      respiratory_rate: nullable,
+    })
+    .nullable(),
+  strain: z
+    .object({
+      day_strain: number,
+      energy_burned_kj: number,
+      last_workout: z
+        .object({
+          sport_name: z.string(),
+          strain: number,
+          occurred_at: z.string(),
+          percent_recorded: number,
+        })
+        .nullable(),
+    })
+    .nullable(),
+  summary: z.string(),
+  data_quality: dataQualitySchema,
+});
+const calendar = z.object({
+  period,
+  days: z.array(
+    z.object({
+      date: z.string(),
+      recovery_score: nullable,
+      recovery_zone: z.enum(["green", "yellow", "red"]).nullable(),
+      sleep_hours: nullable,
+      sleep_performance_pct: nullable,
+      day_strain: nullable,
+    })
+  ),
+  averages: z.object({ recovery: nullable, sleep_hours: nullable, strain: nullable }),
+});
+
+export const outputSchemas: Record<string, z.ZodObject> = {
+  get_profile: z
+    .object({ user_id: number, email: z.string(), first_name: z.string(), last_name: z.string() })
+    .passthrough(),
+  get_body_measurement: z
+    .object({ height_meter: number, weight_kilogram: number, max_heart_rate: number })
+    .passthrough(),
+  get_recovery_collection: collection(recoveryRecordSchema),
+  get_sleep_collection: collection(sleepRecordSchema),
+  get_workout_collection: collection(workoutRecordSchema),
+  get_cycle_collection: collection(cycleRecordSchema),
+  get_sleep_by_id: sleepRecordSchema,
+  get_workout_by_id: workoutRecordSchema,
+  get_cycle_by_id: cycleRecordSchema,
+  get_weekly_summary: weekly,
+  compare_periods: comparison,
+  get_trend: trend,
+  get_today: today,
+  get_calendar: calendar,
+  get_baselines: baselinesOutputSchema,
+  get_sleep_debt: sleepDebtOutputSchema,
+};
+
+const aggregateBand = z.object({
+  sample_size: number,
+  mean: number,
+  median: number,
+  std_dev: number,
+  p10: number,
+  p25: number,
+  p50: number,
+  p75: number,
+  p90: number,
+  constant_baseline: z.boolean(),
+});
+const aggregateQuality = dataQualitySchema
+  .omit({ sources: true, limitations: true, observed_period: true })
+  .extend({
+    sources: z.record(
+      z.string(),
+      z.object({
+        status: z.string(),
+        records_fetched: number,
+        records_used: number,
+        exclusions: z.record(z.string(), number),
+        truncated: z.boolean(),
+      })
+    ),
+  });
+export const aggregateOutputSchemas: Record<string, z.ZodObject> = {
+  get_weekly_summary: weekly
+    .omit({ warnings: true })
+    .extend({ workouts: weekly.shape.workouts.omit({ sport_breakdown: true }) }),
+  compare_periods: comparison,
+  get_trend: trend.omit({ values: true, anomalies: true }),
+  get_baselines: baselinesOutputSchema.extend({
+    metrics: z.record(
+      z.enum(["hrv", "rhr", "respiratory_rate", "sleep_hours", "recovery_score"]),
+      aggregateBand.nullable()
+    ),
+    data_quality: aggregateQuality,
+  }),
+  get_sleep_debt: sleepDebtOutputSchema
+    .omit({ nights: true, standing_debt_hours: true, standing_debt_date: true, summary: true })
+    .extend({ data_quality: aggregateQuality }),
+};
+
+export function projectAggregateDates(data: Record<string, unknown>): Record<string, unknown> {
+  const projected = { ...data };
+  for (const key of ["period", "period_a", "period_b"]) {
+    if (projected[key]) {
+      const periodValue = periodSchema.passthrough().parse(projected[key]);
+      projected[key] = {
+        ...periodValue,
+        start: periodValue.start.slice(0, 10),
+        end: periodValue.end.slice(0, 10),
+      };
+    }
+  }
+  for (const key of ["week_start", "week_end"]) {
+    if (typeof projected[key] === "string") projected[key] = projected[key].slice(0, 10);
+  }
+  if (projected.data_quality) {
+    const quality = aggregateQuality.parse(projected.data_quality);
+    projected.data_quality = {
+      ...quality,
+      requested_period: {
+        start: quality.requested_period.start.slice(0, 10),
+        end: quality.requested_period.end.slice(0, 10),
+      },
+    };
+  }
+  return projected;
+}

--- a/src/tools/stats-utils.ts
+++ b/src/tools/stats-utils.ts
@@ -16,6 +16,37 @@ function assertNonEmpty(values: number[], name: string): void {
   }
 }
 
+export function percentile(values: number[], percent: number): number {
+  assertNonEmpty(values, "percentile");
+  if (
+    !Number.isFinite(percent) ||
+    percent < 0 ||
+    percent > 100 ||
+    values.some((value) => !Number.isFinite(value))
+  ) {
+    throw new RangeError("Percentile requires finite observations and a percentage from 0 to 100.");
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const position = ((sorted.length - 1) * percent) / 100;
+  const lower = Math.floor(position);
+  return sorted[lower]! + (sorted[Math.ceil(position)]! - sorted[lower]!) * (position - lower);
+}
+
+export function circularStats(minutes: number[]): { mean: number | null; sd: number | null } {
+  if (!minutes.length) return { mean: null, sd: null };
+  if (minutes.some((value) => !Number.isFinite(value)))
+    throw new RangeError("Clock times must be finite.");
+  const radians = minutes.map((value) => (value * Math.PI) / 720);
+  const cosine = mean(radians.map(Math.cos));
+  const sine = mean(radians.map(Math.sin));
+  const length = Math.min(1, Math.hypot(cosine, sine));
+  if (length < 1e-10) return { mean: null, sd: null };
+  return {
+    mean: ((Math.atan2(sine, cosine) * 720) / Math.PI + 1440) % 1440,
+    sd: (Math.sqrt(-2 * Math.log(length)) * 720) / Math.PI,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Basic statistics
 // ---------------------------------------------------------------------------

--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -188,7 +188,7 @@ describe("createWhoopClient", () => {
         statusText: "Too Many Requests",
         headers: { get: () => null },
         json: () => Promise.resolve({ retry_after: 30 }),
-        text: () => Promise.resolve("rate limited"),
+        text: () => Promise.resolve('{"retry_after":30}'),
       } as unknown as Response;
       mockFetch
         .mockResolvedValueOnce(response429)
@@ -642,6 +642,85 @@ describe("createWhoopClient", () => {
 
       await expect(client.get("/v2/recovery")).rejects.toThrow(WhoopApiError);
       expect(onTokenRefresh).not.toHaveBeenCalled();
+    });
+
+    it("refreshes token when 401 body is plain text and not valid JSON", async () => {
+      const NEW_TOKEN = "refreshed_token_plain_text";
+      let bodyUsed = false;
+      const nonJson401Response = {
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { get: () => null },
+        // Simulate undici behavior where parsing JSON consumes body and fails.
+        json: async () => {
+          bodyUsed = true;
+          throw new SyntaxError("Unexpected token U in JSON at position 0");
+        },
+        text: async () => {
+          if (bodyUsed) {
+            throw new TypeError("Body is unusable: Body has already been read");
+          }
+          bodyUsed = true;
+          return "Unauthorized";
+        },
+      } as unknown as Response;
+
+      mockFetch
+        .mockResolvedValueOnce(nonJson401Response)
+        .mockResolvedValueOnce(mockJsonResponse({ user_id: 42 }));
+      const onTokenRefresh = vi.fn().mockResolvedValue(NEW_TOKEN);
+      const client = createWhoopClient({
+        accessToken: TEST_TOKEN,
+        baseUrl: TEST_BASE_URL,
+        onTokenRefresh,
+      });
+
+      const result = await client.get<{ user_id: number }>("/v2/user/profile/basic");
+
+      expect(result.user_id).toBe(42);
+      expect(onTokenRefresh).toHaveBeenCalledOnce();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("persists refreshed token across sequential requests", async () => {
+      const NEW_TOKEN = "refreshed_token_persisted";
+      const onTokenRefresh = vi.fn().mockResolvedValue(NEW_TOKEN);
+
+      mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+        const authHeader = (init?.headers as Record<string, string>)["Authorization"];
+
+        if (authHeader === `Bearer ${TEST_TOKEN}`) {
+          return Promise.resolve({
+            ok: false,
+            status: 401,
+            statusText: "Unauthorized",
+            headers: { get: () => null },
+            json: () => Promise.resolve({ message: "Invalid token" }),
+            text: () => Promise.resolve("Unauthorized"),
+          } as unknown as Response);
+        }
+
+        if (authHeader === `Bearer ${NEW_TOKEN}`) {
+          return Promise.resolve(
+            mockJsonResponse({ user_id: 42, tokenUsed: NEW_TOKEN }) as unknown as Response
+          );
+        }
+
+        return Promise.reject(new Error(`unexpected authorization header: ${authHeader}`));
+      });
+
+      const client = createWhoopClient({
+        accessToken: TEST_TOKEN,
+        baseUrl: TEST_BASE_URL,
+        onTokenRefresh,
+      });
+
+      await client.get<{ user_id: number }>("/v2/user/profile/basic");
+      await client.get<{ user_id: number }>("/v2/user/profile/basic");
+
+      expect(onTokenRefresh).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { runDoctor, type DoctorDependencies } from "../../src/cli/doctor.js";
+
+function dependencies(overrides: Partial<DoctorDependencies> = {}): DoctorDependencies {
+  return {
+    env: { WHOOP_CLIENT_ID: "private-id", WHOOP_CLIENT_SECRET: "private-secret" },
+    nodeVersion: "22.0.0",
+    platform: "darwin",
+    inspectToken: vi
+      .fn()
+      .mockResolvedValue({ exists: true, regular: true, mode: 0o600, directoryMode: 0o700 }),
+    write: vi.fn(),
+    ...overrides,
+  };
+}
+afterEach(() => vi.unstubAllGlobals());
+describe("doctor", () => {
+  it("reports local readiness without network requests or secrets", async () => {
+    const fetch = vi.fn(() => {
+      throw new Error("Unexpected network");
+    });
+    vi.stubGlobal("fetch", fetch);
+    const deps = dependencies();
+    expect(await runDoctor(["--json"], deps)).toBe(0);
+    const text = vi.mocked(deps.write).mock.calls[0]![0];
+    expect(JSON.parse(text)).toMatchObject({
+      ready: true,
+      scope_status: "unknown",
+      token_validity: "unknown",
+    });
+    expect(text).not.toContain("private-id");
+    expect(text).not.toContain("private-secret");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+  it.each([
+    { nodeVersion: "18.0.0" },
+    { env: {} },
+    { env: { WHOOP_CLIENT_ID: "x", WHOOP_CLIENT_SECRET: "y", MCP_TRANSPORT: "http" } },
+    {
+      inspectToken: vi
+        .fn()
+        .mockResolvedValue({ exists: false, regular: false, mode: 0, directoryMode: 0 }),
+    },
+    {
+      inspectToken: vi
+        .fn()
+        .mockResolvedValue({ exists: true, regular: true, mode: 0o644, directoryMode: 0o700 }),
+    },
+    {
+      inspectToken: vi
+        .fn()
+        .mockResolvedValue({ exists: true, regular: false, mode: 0o600, directoryMode: 0o700 }),
+    },
+    { platform: "win32" as const },
+  ])("returns remediation status for unsafe local state %j", async (overrides) => {
+    expect(await runDoctor([], dependencies(overrides))).toBe(1);
+  });
+  it("rejects unknown arguments without inspecting tokens", async () => {
+    const deps = dependencies();
+    expect(await runDoctor(["--verify"], deps)).toBe(2);
+    expect(deps.inspectToken).not.toHaveBeenCalled();
+  });
+  it("sanitizes filesystem failures", async () => {
+    const deps = dependencies({
+      inspectToken: vi.fn().mockRejectedValue(new Error("/private/token/path")),
+    });
+    expect(await runDoctor(["--json"], deps)).toBe(1);
+    expect(vi.mocked(deps.write).mock.calls[0]![0]).not.toContain("/private");
+  });
+});

--- a/tests/helpers/analytics-fixtures.ts
+++ b/tests/helpers/analytics-fixtures.ts
@@ -1,0 +1,87 @@
+import { vi } from "vitest";
+import type { WhoopClient } from "../../src/api/client.js";
+import type { Cycle, Recovery, Sleep } from "../../src/api/types.js";
+
+export const ANALYTICS_NOW = new Date("2026-09-10T12:00:00Z");
+export function sleepFixture(index: number): Sleep {
+  const end = new Date(ANALYTICS_NOW.getTime() - index * 86_400_000 - 6 * 3_600_000).toISOString();
+  return {
+    id: `sleep-${index}`,
+    cycle_id: index,
+    user_id: 42,
+    created_at: end,
+    updated_at: end,
+    start: new Date(Date.parse(end) - 8 * 3_600_000).toISOString(),
+    end,
+    timezone_offset: "+00:00",
+    nap: false,
+    score_state: "SCORED",
+    score: {
+      stage_summary: {
+        total_in_bed_time_milli: 28_800_000,
+        total_awake_time_milli: 3_600_000,
+        total_no_data_time_milli: 0,
+        total_light_sleep_time_milli: 14_400_000,
+        total_slow_wave_sleep_time_milli: 3_600_000,
+        total_rem_sleep_time_milli: 7_200_000,
+        sleep_cycle_count: 4,
+        disturbance_count: 1,
+      },
+      sleep_needed: {
+        baseline_milli: 32_400_000,
+        need_from_recent_strain_milli: 0,
+        need_from_recent_nap_milli: -3_600_000,
+        need_from_sleep_debt_milli: 18_000_000,
+      },
+      respiratory_rate: 15,
+    },
+  };
+}
+export function cycleFixture(index: number): Cycle {
+  const sleep = sleepFixture(index);
+  return {
+    id: index,
+    user_id: 42,
+    created_at: sleep.end,
+    updated_at: sleep.end,
+    start: sleep.end,
+    timezone_offset: "+00:00",
+    score_state: "SCORED",
+  };
+}
+export function recoveryFixture(index: number): Recovery {
+  const sleep = sleepFixture(index);
+  return {
+    cycle_id: index,
+    sleep_id: sleep.id,
+    user_id: 42,
+    created_at: sleep.end,
+    updated_at: sleep.end,
+    score_state: "SCORED",
+    score: {
+      user_calibrating: false,
+      recovery_score: 70,
+      resting_heart_rate: 50,
+      hrv_rmssd_milli: index === 0 ? 100 : 40,
+    },
+  };
+}
+export function analyticsClient(count = 20, overrides: Record<string, unknown> = {}): WhoopClient {
+  const data: Record<string, unknown> = {
+    "/v2/activity/sleep": {
+      records: Array.from({ length: count }, (_, index) => sleepFixture(index)),
+    },
+    "/v2/cycle": { records: Array.from({ length: count }, (_, index) => cycleFixture(index)) },
+    "/v2/recovery": {
+      records: Array.from({ length: count }, (_, index) => recoveryFixture(index)),
+    },
+    ...overrides,
+  };
+  return {
+    get: vi.fn(async (path: string) => {
+      const response = data[path.split("?")[0]!];
+      if (response instanceof Error) throw response;
+      return response;
+    }),
+  } as unknown as WhoopClient;
+}

--- a/tests/helpers/stdio-fixture-server.ts
+++ b/tests/helpers/stdio-fixture-server.ts
@@ -1,0 +1,12 @@
+import { createWhoopServer } from "../../src/server.js";
+import { connectStdioTransport } from "../../src/transport/stdio.js";
+import { privacyModeSchema } from "../../src/privacy.js";
+import type { WhoopClient } from "../../src/api/client.js";
+
+const client: WhoopClient = {
+  get: async <Result>(): Promise<Result> => ({ records: [] }) as Result,
+};
+const { server } = createWhoopServer(client, {
+  privacyMode: privacyModeSchema.parse(process.env.WHOOP_MCP_PRIVACY_MODE),
+});
+await connectStdioTransport(server);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -109,6 +109,7 @@ describe("main() entry point", () => {
     delete process.env.MCP_HOST;
     delete process.env.MCP_ALLOWED_ORIGINS;
     delete process.env.LOG_FORMAT;
+    delete process.env.WHOOP_MCP_PRIVACY_MODE;
   });
 
   afterEach(() => {
@@ -122,6 +123,25 @@ describe("main() entry point", () => {
   // -------------------------------------------------------------------------
 
   describe("environment variable validation", () => {
+    it("validates privacy before authentication", async () => {
+      process.env.WHOOP_MCP_PRIVACY_MODE = "raw";
+      setupHappyPath();
+      const { main } = await importMain();
+      await expect(main()).rejects.toThrow();
+      expect(mockAuthenticate).not.toHaveBeenCalled();
+    });
+
+    it("passes aggregate privacy to the server", async () => {
+      process.env.WHOOP_MCP_PRIVACY_MODE = "aggregate";
+      setupHappyPath();
+      const { main } = await importMain();
+      await main();
+      expect(mockCreateWhoopServer).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ privacyMode: "aggregate" })
+      );
+    });
+
     it("throws when WHOOP_CLIENT_ID is missing", async () => {
       delete process.env.WHOOP_CLIENT_ID;
       setupHappyPath();
@@ -343,7 +363,10 @@ describe("main() entry point", () => {
       await main();
 
       expect(mockCreateWhoopServer).toHaveBeenCalledOnce();
-      expect(mockCreateWhoopServer).toHaveBeenCalledWith(mockClient, { disableResources: false });
+      expect(mockCreateWhoopServer).toHaveBeenCalledWith(mockClient, {
+        disableResources: false,
+        privacyMode: "standard",
+      });
     });
 
     it("creates a StdioServerTransport", async () => {

--- a/tests/resources/index.test.ts
+++ b/tests/resources/index.test.ts
@@ -233,7 +233,9 @@ describe("registerResources", () => {
         {
           uri: "whoop://v2/user/recovery/latest",
           mimeType: "application/json",
-          text: JSON.stringify({ error: "API timeout" }),
+          text: JSON.stringify({
+            error: "Resource unavailable. Retry later or verify authorization.",
+          }),
         },
       ],
     });

--- a/tests/server-release.test.ts
+++ b/tests/server-release.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createWhoopServer } from "../src/server.js";
+import { analyticsClient } from "./helpers/analytics-fixtures.js";
+
+async function connected(
+  aggregate: boolean,
+  run: (client: Client) => Promise<void>
+): Promise<void> {
+  const { server } = createWhoopServer(analyticsClient(), {
+    privacyMode: aggregate ? "aggregate" : "standard",
+  });
+  const client = new Client({ name: "release-test", version: "1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    await run(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+describe("release MCP contracts", () => {
+  it("advertises output schemas and returns equivalent structured/text results", async () => {
+    await connected(false, async (client) => {
+      const { tools } = await client.listTools();
+      expect(tools).toHaveLength(16);
+      expect(tools.every((tool) => tool.outputSchema?.type === "object")).toBe(true);
+      for (const name of ["get_baselines", "get_sleep_debt", "get_today"]) {
+        const result = await client.callTool({ name, arguments: {} });
+        expect(result.isError).not.toBe(true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(JSON.parse(content[0]!.text)).toEqual(result.structuredContent);
+      }
+    });
+  });
+  it("exposes only aggregate capabilities and projects both output channels", async () => {
+    await connected(true, async (client) => {
+      const { tools } = await client.listTools();
+      expect(tools.map((tool) => tool.name).sort()).toEqual([
+        "compare_periods",
+        "get_baselines",
+        "get_sleep_debt",
+        "get_trend",
+        "get_weekly_summary",
+      ]);
+      for (const name of ["get_baselines", "get_sleep_debt"]) {
+        const result = await client.callTool({ name, arguments: {} });
+        expect(result.isError).not.toBe(true);
+        const text = JSON.stringify(result);
+        for (const field of [
+          "latest",
+          'nights"',
+          "standing_debt",
+          "user_id",
+          "sleep_id",
+          "source_updated_at",
+        ])
+          expect(text).not.toContain(field);
+        expect(text).not.toContain("observed_period");
+        const data = result.structuredContent as { period: { start: string; end: string } | null };
+        if (data.period) expect(data.period.start).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+      const denied = await client.callTool({ name: "get_profile", arguments: {} });
+      expect(denied.isError).toBe(true);
+      await expect(client.readResource({ uri: "whoop://v2/user/profile" })).rejects.toThrow();
+      await expect(client.getPrompt({ name: "health_check" })).rejects.toThrow();
+    });
+  });
+  it("rejects invalid privacy configuration", () => {
+    expect(() =>
+      createWhoopServer(analyticsClient(), { privacyMode: "raw" as "standard" })
+    ).toThrow();
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -238,7 +238,7 @@ describe("createWhoopServer", () => {
     it("returns all registered tools", async () => {
       const result = await client.listTools();
 
-      expect(result.tools).toHaveLength(14);
+      expect(result.tools).toHaveLength(16);
     });
 
     it("returns tools with the correct names", async () => {
@@ -247,6 +247,7 @@ describe("createWhoopServer", () => {
 
       expect(names).toEqual([
         "compare_periods",
+        "get_baselines",
         "get_body_measurement",
         "get_calendar",
         "get_cycle_by_id",
@@ -255,6 +256,7 @@ describe("createWhoopServer", () => {
         "get_recovery_collection",
         "get_sleep_by_id",
         "get_sleep_collection",
+        "get_sleep_debt",
         "get_today",
         "get_trend",
         "get_weekly_summary",
@@ -634,7 +636,7 @@ describe("createWhoopServer (error handling)", () => {
       expect(result.isError).toBe(true);
       const content = result.content as Array<{ type: string; text: string }>;
       expect(content[0].text).toContain("403");
-      expect(content[0].text).toContain("Forbidden");
+      expect(content[0].text).not.toContain("No access");
       expect(content[0].text).toContain("WHOOP API returned");
     } finally {
       await cleanup();
@@ -665,7 +667,7 @@ describe("createWhoopServer (error handling)", () => {
 
       expect(result.isError).toBe(true);
       const content = result.content as Array<{ type: string; text: string }>;
-      expect(content[0].text).toContain("Authentication error");
+      expect(content[0].text).toContain("authentication failed");
     } finally {
       await cleanup();
     }
@@ -680,8 +682,8 @@ describe("createWhoopServer (error handling)", () => {
 
       expect(result.isError).toBe(true);
       const content = result.content as Array<{ type: string; text: string }>;
-      expect(content[0].text).toContain("Unexpected error");
-      expect(content[0].text).toContain("Something went wrong");
+      expect(content[0].text).toContain("unexpected error");
+      expect(content[0].text).not.toContain("Something went wrong");
     } finally {
       await cleanup();
     }
@@ -715,8 +717,8 @@ describe("createWhoopServer (error handling)", () => {
       expect(result.isError).toBe(true);
       const content = result.content as Array<{ type: string; text: string }>;
       expect(content[0].text).toContain("503");
-      expect(content[0].text).toContain("Service Unavailable");
-      expect(content[0].text).toContain("plain text error body");
+      expect(content[0].text).toContain("Retry later");
+      expect(content[0].text).not.toContain("plain text error body");
     } finally {
       await cleanup();
     }
@@ -739,7 +741,7 @@ describe("createWhoopServer (error handling)", () => {
 
       expect(result.isError).toBe(true);
       const content = result.content as Array<{ type: string; text: string }>;
-      expect(content[0].text).toBe("An unexpected error occurred");
+      expect(content[0].text).toBe("An unexpected error occurred. Check configuration and retry.");
     } finally {
       await mcpClient.close();
       await server.close();

--- a/tests/tools/analytics-utils.test.ts
+++ b/tests/tools/analytics-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { percentile, circularStats } from "../../src/tools/stats-utils.js";
+import { localDay } from "../../src/tools/analytics-utils.js";
+
+describe("analytics primitives", () => {
+  it("interpolates percentiles without mutating values", () => {
+    const values = [30, 0, 10, 20];
+    expect(percentile(values, 25)).toBe(7.5);
+    expect(percentile(values, 0)).toBe(0);
+    expect(percentile(values, 100)).toBe(30);
+    expect(values).toEqual([30, 0, 10, 20]);
+    expect(() => percentile([], 50)).toThrow();
+    expect(() => percentile([1], 101)).toThrow();
+    expect(() => percentile([NaN], 50)).toThrow();
+  });
+  it("handles midnight and undefined antipodal means", () => {
+    const result = circularStats([1430, 10]);
+    expect(Math.min(result.mean!, 1440 - result.mean!)).toBeCloseTo(0);
+    expect(result.sd).toBeCloseTo(10, 0);
+    expect(circularStats([0, 720])).toEqual({ mean: null, sd: null });
+    expect(circularStats([])).toEqual({ mean: null, sd: null });
+  });
+  it("uses the recorded offset rather than the host timezone", () => {
+    expect(localDay("2026-09-10T01:00:00Z", "-05:00")).toBe("2026-09-09");
+    expect(localDay("2026-03-08T06:30:00Z", "-05:00")).toBe("2026-03-08");
+    expect(localDay("2026-11-01T06:30:00Z", "-04:00")).toBe("2026-11-01");
+  });
+});

--- a/tests/tools/get-baselines.test.ts
+++ b/tests/tools/get-baselines.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { getBaselines } from "../../src/tools/get-baselines.js";
+import { analyticsClient, ANALYTICS_NOW, recoveryFixture } from "../helpers/analytics-fixtures.js";
+
+describe("getBaselines", () => {
+  it("excludes latest and current day, uses midrank ties and flags constant baselines", async () => {
+    const result = await getBaselines(analyticsClient(), {}, ANALYTICS_NOW);
+    expect(result.metrics.hrv).toMatchObject({
+      mean: 40,
+      latest: 100,
+      latest_percentile: 100,
+      sample_size: 19,
+      constant_baseline: true,
+    });
+    expect(result.metrics.rhr?.latest_percentile).toBe(50);
+    expect(result.data_quality.sources.recovery?.cache_status).toBe("unknown");
+    expect(result.disclaimer).toContain("not medical advice");
+  });
+  it("returns null bands below 14 historical points", async () => {
+    const result = await getBaselines(analyticsClient(14), {}, ANALYTICS_NOW);
+    expect(result.metrics.hrv).toBeNull();
+    expect(result.metric_status.hrv).toMatchObject({
+      sample_size: 13,
+      status: "insufficient_data",
+    });
+  });
+  it("excludes calibration and missing cycle context without affecting sleep", async () => {
+    const records = Array.from({ length: 20 }, (_, index) => recoveryFixture(index));
+    records[1]!.score!.user_calibrating = true;
+    const result = await getBaselines(
+      analyticsClient(20, { "/v2/recovery": { records }, "/v2/cycle": { records: [] } }),
+      {},
+      ANALYTICS_NOW
+    );
+    expect(result.metrics.hrv).toBeNull();
+    expect(result.metrics.sleep_hours?.mean).toBe(7);
+    expect(result.data_quality.sources.recovery?.exclusions.calibrating).toBe(1);
+    expect(result.data_quality.sources.recovery?.exclusions.missing_join).toBe(19);
+  });
+  it("retains sleep baselines when recovery fetching fails", async () => {
+    const result = await getBaselines(
+      analyticsClient(20, { "/v2/recovery": new Error("secret") }),
+      {},
+      ANALYTICS_NOW
+    );
+    expect(result.metrics.hrv).toBeNull();
+    expect(result.metrics.sleep_hours).not.toBeNull();
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+  it("rejects out-of-range inputs", async () => {
+    await expect(
+      getBaselines(analyticsClient(), { baseline_days: 181 }, ANALYTICS_NOW)
+    ).rejects.toThrow();
+  });
+
+  it("reports truncation without silently presenting complete history", async () => {
+    const result = await getBaselines(
+      analyticsClient(0, {
+        "/v2/recovery": {
+          records: Array.from({ length: 501 }, (_, index) => recoveryFixture(index)),
+          next_token: "more",
+        },
+      }),
+      { baseline_days: 180 },
+      ANALYTICS_NOW
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.data_quality.sources.recovery?.records_fetched).toBe(500);
+    expect(result.data_quality.limitations.join(" ")).toContain("Partial history");
+  });
+});

--- a/tests/tools/get-sleep-debt.test.ts
+++ b/tests/tools/get-sleep-debt.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { getSleepDebt } from "../../src/tools/get-sleep-debt.js";
+import { analyticsClient, ANALYTICS_NOW, sleepFixture } from "../helpers/analytics-fixtures.js";
+
+describe("getSleepDebt", () => {
+  it("resolves relative dates against the injected evaluation clock", async () => {
+    const result = await getSleepDebt(
+      analyticsClient(),
+      { start: "yesterday", days: 3 },
+      new Date("2026-08-10T12:00:00Z")
+    );
+    expect(result.period.start).toBe("2026-08-09T00:00:00.000Z");
+  });
+
+  it.each([{ records: "invalid" }, {}, { records: [], next_token: 42 }])(
+    "distinguishes malformed pages %j from network failures",
+    async (page) => {
+      const result = await getSleepDebt(
+        analyticsClient(0, { "/v2/activity/sleep": page }),
+        {},
+        ANALYTICS_NOW
+      );
+      expect(result.status).toBe("insufficient_data");
+      expect(result.data_quality.sources.sleep?.status).toBe("invalid");
+    }
+  );
+
+  it("preserves nap adjustment, uses asleep stages, and separates standing debt", async () => {
+    const result = await getSleepDebt(analyticsClient(4), {}, ANALYTICS_NOW);
+    expect(result.nights[0]).toMatchObject({ needed_hours: 8, achieved_hours: 7, debt_hours: 1 });
+    expect(result.total_debt_hours).toBe(4);
+    expect(result.standing_debt_hours).toBe(5);
+    expect(result.consistency.bedtime_std_dev_minutes).toBeCloseTo(0);
+  });
+  it("excludes naps and pending scores, picks longest main sleep per day", async () => {
+    const records = [
+      sleepFixture(1),
+      sleepFixture(2),
+      sleepFixture(3),
+      { ...sleepFixture(1), id: "nap", nap: true },
+      { ...sleepFixture(4), score_state: "PENDING_SCORE" },
+      { ...sleepFixture(1), id: "short", start: "2026-09-09T05:00:00Z" },
+    ];
+    const result = await getSleepDebt(
+      analyticsClient(0, { "/v2/activity/sleep": { records } }),
+      {},
+      ANALYTICS_NOW
+    );
+    expect(result.nights_analyzed).toBe(3);
+    expect(result.total_debt_hours).toBe(3);
+    expect(result.data_quality.sources.sleep?.exclusions.nap).toBe(1);
+    expect(result.data_quality.sources.sleep?.exclusions.pending).toBe(1);
+  });
+  it("returns null aggregates for insufficient data", async () => {
+    const result = await getSleepDebt(analyticsClient(2), {}, ANALYTICS_NOW);
+    expect(result.total_debt_hours).toBeNull();
+    expect(result.status).toBe("insufficient_data");
+    expect(result.consistency.social_jetlag_minutes).toBeNull();
+  });
+
+  it("keeps weekend-only social jetlag null and treats surplus as zero deficit", async () => {
+    const records = [4, 11, 18].map((index) => sleepFixture(index));
+    for (const record of records) record.score!.sleep_needed.baseline_milli = 14_400_000;
+    const result = await getSleepDebt(
+      analyticsClient(0, { "/v2/activity/sleep": { records } }),
+      { days: 30 },
+      ANALYTICS_NOW
+    );
+    expect(result.nights_analyzed).toBe(3);
+    expect(result.total_debt_hours).toBe(0);
+    expect(result.consistency.social_jetlag_minutes).toBeNull();
+  });
+
+  it("rejects invalid needs and preserves missing-night counts", async () => {
+    const invalid = sleepFixture(1);
+    invalid.score!.sleep_needed.need_from_recent_nap_milli = -100_000_000;
+    const result = await getSleepDebt(
+      analyticsClient(0, {
+        "/v2/activity/sleep": { records: [invalid, sleepFixture(2), sleepFixture(5)] },
+      }),
+      {},
+      ANALYTICS_NOW
+    );
+    expect(result.nights_analyzed).toBe(2);
+    expect(result.total_debt_hours).toBeNull();
+    expect(result.data_quality.sources.sleep?.exclusions.invalid_need).toBe(1);
+  });
+  it("caps echoed nights without reducing the analyzed set", async () => {
+    const result = await getSleepDebt(analyticsClient(60), { days: 90 }, ANALYTICS_NOW);
+    expect(result.nights).toHaveLength(30);
+    expect(result.nights_analyzed).toBe(60);
+    expect(result.output_capped).toBe(true);
+    expect(result.truncated).toBe(false);
+  });
+  it("rejects future starts and returns resolved historical windows", async () => {
+    await expect(
+      getSleepDebt(analyticsClient(), { start: "2027-01-01" }, ANALYTICS_NOW)
+    ).rejects.toThrow();
+    const result = await getSleepDebt(
+      analyticsClient(),
+      { start: "2026-09-01", days: 3 },
+      ANALYTICS_NOW
+    );
+    expect(result.period).toEqual({
+      start: "2026-09-01T00:00:00.000Z",
+      end: "2026-09-04T00:00:00.000Z",
+    });
+  });
+});

--- a/tests/tools/get-today.test.ts
+++ b/tests/tools/get-today.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { WhoopClient } from "../../src/api/client.js";
+import { WhoopNetworkError } from "../../src/api/client.js";
 import { getToday } from "../../src/tools/get-today.js";
 import type { Recovery, Sleep, Cycle, Workout } from "../../src/api/types.js";
 
@@ -134,6 +135,143 @@ function createMockClient(responses: Record<string, unknown>): WhoopClient {
 // ---------------------------------------------------------------------------
 
 describe("getToday", () => {
+  it("accepts an open cycle with a null end and classifies null pending scores", async () => {
+    const result = await getToday(
+      createMockClient({
+        "/v2/recovery": { records: [mockRecovery] },
+        "/v2/cycle": { records: [{ ...mockCycle, end: null }] },
+        "/v2/activity/sleep": {
+          records: [{ ...mockSleep, score_state: "PENDING_SCORE", score: null }],
+        },
+        "/v2/activity/workout": { records: [] },
+      })
+    );
+    expect(result.strain?.day_strain).toBe(8.4);
+    expect(result.recovery).toBeNull();
+    expect(result.data_quality.sources.sleep?.status).toBe("pending");
+  });
+
+  it("does not substitute older sleep when the newest primary sleep has an invalid score", async () => {
+    const result = await getToday(
+      createMockClient({
+        "/v2/recovery": { records: [mockRecovery] },
+        "/v2/cycle": { records: [mockCycle] },
+        "/v2/activity/sleep": {
+          records: [
+            {
+              ...mockSleep,
+              id: "newest",
+              end: "2026-03-15T07:00:00Z",
+              score: { ...mockSleep.score, respiratory_rate: NaN },
+            },
+            mockSleep,
+          ],
+        },
+        "/v2/activity/workout": { records: [] },
+      })
+    );
+    expect(result.sleep).toBeNull();
+    expect(result.recovery).toBeNull();
+    expect(result.data_quality.sources.sleep?.status).toBe("invalid");
+  });
+
+  it.each([
+    {
+      label: "mismatched sleep",
+      recovery: { ...mockRecovery, sleep_id: "other" },
+      cycle: mockCycle,
+    },
+    { label: "mismatched cycle", recovery: { ...mockRecovery, cycle_id: 999 }, cycle: mockCycle },
+    {
+      label: "stale cycle",
+      recovery: mockRecovery,
+      cycle: { ...mockCycle, start: "2026-03-13T06:00:00Z" },
+    },
+  ])("suppresses recovery for $label", async ({ recovery, cycle }) => {
+    const result = await getToday(
+      createMockClient({
+        "/v2/recovery": { records: [recovery] },
+        "/v2/cycle": { records: [cycle] },
+        "/v2/activity/sleep": { records: [mockSleep] },
+        "/v2/activity/workout": { records: [] },
+      })
+    );
+    expect(result.recovery).toBeNull();
+  });
+
+  it("skips a latest nap and exposes separate sleep durations and evidence", async () => {
+    const result = await getToday(
+      createMockClient({
+        "/v2/recovery": { records: [mockRecovery] },
+        "/v2/cycle": { records: [mockCycle] },
+        "/v2/activity/sleep": {
+          records: [{ ...mockSleep, id: "nap", nap: true }, mockSleep],
+          next_token: "more",
+        },
+        "/v2/activity/workout": { records: [mockWorkout] },
+      })
+    );
+    expect(result.sleep).toMatchObject({
+      total_hours: 7.5,
+      time_in_bed_hours: 7.5,
+      asleep_hours: 6.5,
+    });
+    expect(result.data_quality.sources.sleep).toMatchObject({
+      truncated: true,
+      fetched_at: null,
+      cache_status: "unknown",
+    });
+    expect(result.strain?.last_workout).toMatchObject({ occurred_at: mockWorkout.start });
+  });
+
+  it("uses the recorded offset near local midnight", async () => {
+    vi.setSystemTime(new Date("2026-03-16T01:00:00Z"));
+    const result = await getToday(
+      createMockClient({
+        "/v2/recovery": { records: [mockRecovery] },
+        "/v2/cycle": { records: [mockCycle] },
+        "/v2/activity/sleep": { records: [mockSleep] },
+        "/v2/activity/workout": { records: [] },
+      })
+    );
+    expect(result.recovery?.score).toBe(72);
+  });
+
+  it("reports absent optional values as null and excludes invalid scores", async () => {
+    const result = await getToday(
+      createMockClient({
+        "/v2/recovery": {
+          records: [{ ...mockRecovery, score: { ...mockRecovery.score, hrv_rmssd_milli: NaN } }],
+        },
+        "/v2/cycle": { records: [mockCycle] },
+        "/v2/activity/sleep": {
+          records: [
+            {
+              ...mockSleep,
+              score: { ...mockSleep.score, sleep_performance_percentage: undefined },
+            },
+          ],
+        },
+        "/v2/activity/workout": { records: [] },
+      })
+    );
+    expect(result.sleep?.performance_pct).toBeNull();
+    expect(result.recovery).toBeNull();
+    expect(result.data_quality.sources.recovery?.exclusions.invalid).toBe(1);
+  });
+
+  it("does not expose recovery while the matching primary sleep is pending", async () => {
+    const client = createMockClient({
+      "/v2/recovery": { records: [mockRecovery] },
+      "/v2/activity/sleep": { records: [{ ...mockSleep, score_state: "PENDING_SCORE" }] },
+      "/v2/cycle": { records: [mockCycle] },
+      "/v2/activity/workout": { records: [] },
+    });
+    const result = await getToday(client);
+    expect(result.recovery).toBeNull();
+    expect(result.sleep).toBeNull();
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
@@ -190,7 +328,7 @@ describe("getToday", () => {
     const result = await getToday(client);
 
     expect(result.summary).toContain("72%");
-    expect(result.summary).toContain("7.5h sleep");
+    expect(result.summary).toContain("6.5h sleep");
     expect(result.summary).toContain("8.4");
   });
 
@@ -219,7 +357,7 @@ describe("getToday", () => {
 
     const result = await getToday(client);
 
-    expect(result.recovery).not.toBeNull();
+    expect(result.recovery).toBeNull();
     expect(result.sleep).toBeNull();
     expect(result.strain).not.toBeNull();
   });
@@ -234,7 +372,7 @@ describe("getToday", () => {
 
     const result = await getToday(client);
 
-    expect(result.recovery).not.toBeNull();
+    expect(result.recovery).toBeNull();
     expect(result.sleep).not.toBeNull();
     expect(result.strain).toBeNull();
   });
@@ -247,7 +385,7 @@ describe("getToday", () => {
       "/v2/activity/workout": new Error("fail 4"),
     });
 
-    await expect(getToday(client)).rejects.toThrow(/all.*failed/i);
+    await expect(getToday(client)).rejects.toBeInstanceOf(WhoopNetworkError);
   });
 
   it("throws when all 3 primary endpoints fail (even if workout succeeds)", async () => {
@@ -258,7 +396,7 @@ describe("getToday", () => {
       "/v2/activity/workout": { records: [mockWorkout], next_token: undefined },
     });
 
-    await expect(getToday(client)).rejects.toThrow(/all.*failed/i);
+    await expect(getToday(client)).rejects.toBeInstanceOf(WhoopNetworkError);
   });
 
   it("returns null recovery when no recovery records exist", async () => {
@@ -371,7 +509,7 @@ describe("getToday", () => {
     expect(result.strain).toBeNull();
   });
 
-  it("generates summary with partial data (recovery only)", async () => {
+  it("does not summarize unverifiable recovery without sleep and cycle context", async () => {
     const client = createMockClient({
       "/v2/recovery": { records: [mockRecovery], next_token: undefined },
       "/v2/activity/sleep": new Error("fail"),
@@ -381,9 +519,8 @@ describe("getToday", () => {
 
     const result = await getToday(client);
 
-    expect(result.summary).toContain("72%");
-    expect(result.summary).not.toContain("sleep");
-    expect(result.summary).not.toContain("strain");
+    expect(result.recovery).toBeNull();
+    expect(result.summary).not.toContain("72%");
   });
 
   it("generates summary with sleep missing spo2 and skin_temp", async () => {

--- a/tests/transport/http-mcp-integration.test.ts
+++ b/tests/transport/http-mcp-integration.test.ts
@@ -13,6 +13,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { createHttpServer } from "../../src/transport/http.js";
 import { createWhoopServer } from "../../src/server.js";
 import type { WhoopClient } from "../../src/api/client.js";
+import { analyticsClient } from "../helpers/analytics-fixtures.js";
 
 function makeMockWhoopClient(): WhoopClient {
   return {
@@ -27,6 +28,34 @@ function makeMockWhoopClient(): WhoopClient {
 }
 
 describe("HTTP transport — MCP integration", () => {
+  it("enforces aggregate privacy and structured results over HTTP", async () => {
+    const { server } = createWhoopServer(analyticsClient(), { privacyMode: "aggregate" });
+    const http = await createHttpServer({ authToken: "privacy-test-token", port: 0 });
+    await server.connect(http.transport);
+    const address = http.server.address();
+    if (!address || typeof address === "string") throw new Error("Missing port");
+    const client = new Client({ name: "privacy-test", version: "1" });
+    try {
+      await client.connect(
+        new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`), {
+          requestInit: { headers: { Authorization: "Bearer privacy-test-token" } },
+        })
+      );
+      expect((await client.listTools()).tools).toHaveLength(5);
+      const result = await client.callTool({ name: "get_sleep_debt", arguments: {} });
+      expect(result.isError).not.toBe(true);
+      expect(result.structuredContent).toBeDefined();
+      expect(JSON.stringify(result)).not.toContain('"nights"');
+      expect((await client.callTool({ name: "get_today", arguments: {} })).isError).toBe(true);
+      await expect(client.readResource({ uri: "whoop://v2/user/profile" })).rejects.toThrow();
+      await expect(client.getPrompt({ name: "health_check" })).rejects.toThrow();
+    } finally {
+      await client.close();
+      await server.close();
+      await http.close();
+    }
+  });
+
   let cleanup: (() => Promise<void>) | null = null;
 
   afterEach(async () => {

--- a/tests/transport/stdio-mcp-integration.test.ts
+++ b/tests/transport/stdio-mcp-integration.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+describe("stdio release contracts", () => {
+  it.each(["standard", "aggregate"])(
+    "supports %s mode through an actual child process",
+    async (mode) => {
+      const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: ["--import", "tsx", "tests/helpers/stdio-fixture-server.ts"],
+        env: { WHOOP_MCP_PRIVACY_MODE: mode },
+        stderr: "pipe",
+      });
+      const client = new Client({ name: "stdio-test", version: "1" });
+      try {
+        await client.connect(transport);
+        expect((await client.listTools()).tools).toHaveLength(mode === "standard" ? 16 : 5);
+        const result = await client.callTool({ name: "get_sleep_debt", arguments: {} });
+        expect(result.isError).not.toBe(true);
+        const content = result.content as Array<{ text: string }>;
+        expect(JSON.parse(content[0]!.text)).toEqual(result.structuredContent);
+        if (mode === "aggregate") {
+          expect(JSON.stringify(result)).not.toContain('"nights"');
+          expect((await client.callTool({ name: "get_profile", arguments: {} })).isError).toBe(
+            true
+          );
+          await expect(client.readResource({ uri: "whoop://v2/user/profile" })).rejects.toThrow();
+          await expect(client.getPrompt({ name: "health_check" })).rejects.toThrow();
+        }
+      } finally {
+        await client.close();
+        await transport.close();
+      }
+    },
+    15_000
+  );
+});


### PR DESCRIPTION
# PR: Add Trustworthy Personal Analytics And Aggregate Privacy

## Summary

Prepare the approved 0.7.0 feature scope without publishing or changing package
version metadata beyond the previously local 0.6.1 baseline. Standard mode offers 16 tools, four resources and five prompts.
Aggregate mode exposes only five summary/analytics tools.

This branch also includes the two previously local baseline commits: the 401
error/token-persistence fix and the 0.6.1 version update. It does not bump to 0.7.0.

- Add personal baseline distributions and sleep-debt analysis with explicit sample
  counts, bounded history, baseline self-exclusion and insufficient-data states.
- Match current-day recovery to its cycle and primary sleep. Suppress stale,
  pending, invalid or unjoinable results instead of substituting older scores.
- Advertise output schemas and return equivalent structured content and JSON text.
- Enforce process-level aggregate privacy at registration and output boundaries;
  sanitize tool/resource errors and minimize exact-record metadata.
- Add local-only `doctor` diagnostics and compatible dependency advisory fixes.
- Update README, changelog and site together. The site explicitly distinguishes
  upcoming 0.7.0 functionality from the published 0.6.1 install commands.

## Compatibility

- Default mode remains `standard`; existing tool names and input defaults remain.
- `get_today.sleep.total_hours` retains time-in-bed semantics. New
  `time_in_bed_hours` and `asleep_hours` fields are explicit; summaries use asleep time.
- Missing optional sleep percentages now return null, not zero.
- `WHOOP_MCP_PRIVACY_MODE=aggregate` hides raw tools, resources and incompatible
  prompts. Tool arguments cannot override the policy; reconnect after changing it.
- Calendar/weekly-summary UTC grouping stays unchanged. New analytics uses recorded
  offsets; these cannot reconstruct future timezone rules or within-sleep DST changes.
- No new direct runtime dependency, WHOOP endpoint, OAuth scope or persisted health store.
- Remaining Task 16 analytics, forecasts, webhooks, UI apps and local databases are not included.

## Verification

- [x] 797 tests across 43 files; all WHOOP responses in automated tests are synthetic.
- [x] Real stdio subprocess and authenticated HTTP contract/privacy tests.
- [x] Lint, typecheck, build, source/test formatting and whitespace checks.
- [x] Coverage: 95.61% overall lines, 98.84% API, 99.18% auth.
- [x] Production dependency audit: zero findings after targeted compatible updates.
- [x] Built local-only diagnostics smoke test; no OAuth or health API calls.
- [x] Site browser checks at 1440px, 390px and 320px: no horizontal overflow,
      valid internal anchors, matching copy-command payloads, desktop/mobile screenshots.

## Known Risks And Release Follow-Ups

- Three moderate development-only Vitest audit entries remain for the redirect-mock
  advisory. Remediation requires a separate major-version migration; do not expose
  test/development servers to untrusted clients.
- [ ] Manually verify Claude Desktop or VS Code display/discovery in both privacy modes.
- [ ] Complete human release review, then synchronize package, lockfile and MCP registry
      version metadata to 0.7.0 and authorize publication. Existing registry metadata is 0.6.0;
      package metadata is 0.6.1. Neither is bumped in this feature PR preparation.

References: [release specification](https://github.com/shashankswe2020-ux/whoop-mcp/blob/feature/v070-personal-analytics/docs/specs/v070-trustworthy-personal-analytics.md),
[execution checklist](https://github.com/shashankswe2020-ux/whoop-mcp/blob/feature/v070-personal-analytics/docs/plans/task-17-v070-trustworthy-personal-analytics.md),
[implementation review and security triage](https://github.com/shashankswe2020-ux/whoop-mcp/blob/feature/v070-personal-analytics/docs/reviews/v070-implementation-review.md).

## Scope Note

Supporting analytics/coaching drafts are included as historical design context,
not as additional implemented scope. Pre-existing edits to the Task 14 and Task 15
plans and the general implementation plan are left outside this PR. No package
publication is performed by opening this PR.
